### PR TITLE
운동 참석, helper 랭킹 서비스 

### DIFF
--- a/src/components/RankingTable.tsx
+++ b/src/components/RankingTable.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+export interface RankingMember {
+  id: number;
+  name: string;
+  count: number;
+}
+
+interface RankingTableProps {
+  attendanceRanking: RankingMember[];
+  helperRanking: RankingMember[];
+}
+
+const RankingTable: React.FC<RankingTableProps> = ({
+  attendanceRanking,
+  helperRanking,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const initialDisplayCount = 10;
+
+  // 표시할 아이템 수 결정
+  const displayCount = expanded
+    ? Math.max(attendanceRanking.length, helperRanking.length)
+    : initialDisplayCount;
+
+  // 빈 배열로 채워 동일한 길이로 만들기
+  const paddedAttendance = [...attendanceRanking];
+  const paddedHelper = [...helperRanking];
+
+  // 최대 행 수 계산
+  const maxRows = Math.max(
+    Math.min(displayCount, attendanceRanking.length),
+    Math.min(displayCount, helperRanking.length)
+  );
+
+  const toggleExpanded = () => {
+    setExpanded(!expanded);
+  };
+
+  return (
+    <div className="mt-8">
+      <h3 className="font-bold mb-4">랭킹</h3>
+      <div className="border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="px-4 py-2 text-left w-16">#</th>
+              <th className="px-4 py-2 text-left">출석</th>
+              <th className="px-4 py-2 text-left">도우미</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: maxRows }).map((_, index) => (
+              <tr key={index} className="border-t">
+                <td className="px-4 py-2 font-medium">{index + 1}</td>
+                <td className="px-4 py-2">
+                  {paddedAttendance[index] ? (
+                    <div className="flex justify-between">
+                      <span>{paddedAttendance[index].name}</span>
+                      <span className="text-gray-500">
+                        {paddedAttendance[index].count}회
+                      </span>
+                    </div>
+                  ) : (
+                    '-'
+                  )}
+                </td>
+                <td className="px-4 py-2">
+                  {paddedHelper[index] ? (
+                    <div className="flex justify-between">
+                      <span>{paddedHelper[index].name}</span>
+                      <span className="text-gray-500">
+                        {paddedHelper[index].count}회
+                      </span>
+                    </div>
+                  ) : (
+                    '-'
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {(attendanceRanking.length > initialDisplayCount ||
+          helperRanking.length > initialDisplayCount) && (
+          <div
+            className="text-center py-2 border-t cursor-pointer hover:bg-gray-50"
+            onClick={toggleExpanded}
+          >
+            {expanded ? (
+              <div className="flex items-center justify-center text-gray-500">
+                <span>접기</span>
+                <ChevronUp size={16} className="ml-1" />
+              </div>
+            ) : (
+              <div className="flex items-center justify-center text-gray-500">
+                <span>더보기</span>
+                <ChevronDown size={16} className="ml-1" />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RankingTable;

--- a/src/components/RankingTable.tsx
+++ b/src/components/RankingTable.tsx
@@ -39,9 +39,10 @@ const RankingTable: React.FC<RankingTableProps> = ({
     setExpanded(!expanded);
   };
 
+  const currentDate = new Date().getMonth() + 1;
   return (
     <div className="mt-8">
-      <h3 className="font-bold mb-4">랭킹</h3>
+      <h3 className="font-bold mb-4">{currentDate}월 랭킹</h3>
       <div className="border rounded-lg overflow-hidden">
         <table className="w-full text-sm">
           <thead>

--- a/src/pages/api/clubs/[id]/rankings.ts
+++ b/src/pages/api/clubs/[id]/rankings.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client';
 
 import { ApiResponse } from '@/types';
 import { getMonthRange } from '@/utils/date';
+import { sortRankingByCountAndId } from '@/utils/sort';
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -122,17 +123,23 @@ export default async function handler(
     });
 
     // 결과 포맷팅
-    const formattedAttendanceRanking = attendanceRanking.map((member) => ({
-      id: member.id,
-      name: member.name || `회원 ${member.id}`,
-      count: member._count.workoutParticipants,
-    }));
+    const formattedAttendanceRanking = attendanceRanking
+      .map((member) => ({
+        id: member.id,
+        name: member.name || `회원 ${member.id}`,
+        count: member._count.workoutParticipants,
+      }))
+      // 출석 랭킹 정렬
+      .sort(sortRankingByCountAndId);
 
-    const formattedHelperRanking = helperRanking.map((member) => ({
-      id: member.id,
-      name: member.name || `회원 ${member.id}`,
-      count: member._count.helperStatuses,
-    }));
+    const formattedHelperRanking = helperRanking
+      .map((member) => ({
+        id: member.id,
+        name: member.name || `회원 ${member.id}`,
+        count: member._count.helperStatuses,
+      }))
+      // 헬퍼 랭킹 정렬
+      .sort(sortRankingByCountAndId);
 
     return res.status(200).json({
       data: {

--- a/src/pages/api/clubs/[id]/rankings.ts
+++ b/src/pages/api/clubs/[id]/rankings.ts
@@ -1,0 +1,156 @@
+import { PrismaClient } from '@prisma/client';
+
+import { ApiResponse } from '@/types';
+import { getMonthRange } from '@/utils/date';
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface RankingMember {
+  id: number;
+  name: string;
+  count: number;
+}
+
+interface Rankings {
+  attendance: RankingMember[];
+  helper: RankingMember[];
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse<'rankings', Rankings>>
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({
+      error: '허용되지 않는 메소드입니다',
+      status: 405,
+    });
+  }
+
+  const { id } = req.query;
+  const clubId = Number(id);
+  const prisma = new PrismaClient();
+
+  try {
+    // 현재 달의 시작과 끝 날짜 계산
+    const { startOfMonth, endOfMonth } = getMonthRange();
+
+    // 1. 현재 달에 해당 클럽의 운동 목록 조회
+    const workouts = await prisma.workout.findMany({
+      where: {
+        clubId,
+        date: {
+          gte: startOfMonth,
+          lte: endOfMonth,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    const workoutIds = workouts.map((workout) => workout.id);
+
+    // 2. 출석 랭킹 (참여자 수 기준)
+    const attendanceRanking = await prisma.clubMember.findMany({
+      where: {
+        clubId,
+        workoutParticipants: {
+          some: {
+            workoutId: {
+              in: workoutIds,
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+        _count: {
+          select: {
+            workoutParticipants: {
+              where: {
+                workoutId: {
+                  in: workoutIds,
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        workoutParticipants: {
+          _count: 'desc',
+        },
+      },
+    });
+
+    // 3. 헬퍼 랭킹 (헬퍼 활동 수 기준)
+    const helperRanking = await prisma.clubMember.findMany({
+      where: {
+        clubId,
+        helperStatuses: {
+          some: {
+            workoutId: {
+              in: workoutIds,
+            },
+            helped: true,
+          },
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+        _count: {
+          select: {
+            helperStatuses: {
+              where: {
+                workoutId: {
+                  in: workoutIds,
+                },
+                helped: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        helperStatuses: {
+          _count: 'desc',
+        },
+      },
+    });
+
+    // 결과 포맷팅
+    const formattedAttendanceRanking = attendanceRanking.map((member) => ({
+      id: member.id,
+      name: member.name || `회원 ${member.id}`,
+      count: member._count.workoutParticipants,
+    }));
+
+    const formattedHelperRanking = helperRanking.map((member) => ({
+      id: member.id,
+      name: member.name || `회원 ${member.id}`,
+      count: member._count.helperStatuses,
+    }));
+
+    return res.status(200).json({
+      data: {
+        rankings: {
+          attendance: formattedAttendanceRanking,
+          helper: formattedHelperRanking,
+        },
+      },
+      status: 200,
+      message: '랭킹 정보를 성공적으로 가져왔습니다',
+    });
+  } catch (error) {
+    console.error('랭킹 정보 조회 중 오류 발생:', error);
+    return res.status(500).json({
+      error: '랭킹 정보를 가져오는데 실패했습니다',
+      status: 500,
+    });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/src/pages/clubs/[id]/index.tsx
+++ b/src/pages/clubs/[id]/index.tsx
@@ -1,16 +1,29 @@
+import { useEffect, useState } from 'react';
+
 import { useRouter } from 'next/router';
 
 import axios from 'axios';
 import { useSelector } from 'react-redux';
 
 import { JoinClubButton } from '@/components/molecules/buttons/JoinClubButton';
+import RankingTable, { RankingMember } from '@/components/RankingTable';
 import { withAuth } from '@/lib/withAuth';
 import { RootState } from '@/store';
 import { ClubJoinFormData, ClubDetailPageProps } from '@/types';
 
+interface RankingsData {
+  attendance: RankingMember[];
+  helper: RankingMember[];
+}
+
 function ClubDetailPage({ user }: ClubDetailPageProps) {
   const router = useRouter();
   const { id: clubId } = router.query;
+  const [rankings, setRankings] = useState<RankingsData>({
+    attendance: [],
+    helper: [],
+  });
+  const [isRankingLoading, setIsRankingLoading] = useState(false);
 
   const club = useSelector((state: RootState) => state.club.currentClub);
   const membershipStatus = useSelector(
@@ -22,6 +35,27 @@ function ClubDetailPage({ user }: ClubDetailPageProps) {
     user && !membershipStatus.isMember && !membershipStatus.isPending;
   const isAbleJoinclubButton =
     !user || membershipStatus.isPending || canJoinClub;
+
+  // 랭킹 데이터 로드
+  useEffect(() => {
+    if (clubId) {
+      loadRankings();
+    }
+  }, [clubId]);
+
+  const loadRankings = async () => {
+    setIsRankingLoading(true);
+    try {
+      const response = await axios.get(`/api/clubs/${clubId}/rankings`);
+      if (response.status === 200) {
+        setRankings(response.data.data.rankings);
+      }
+    } catch (error) {
+      console.error('랭킹 정보를 불러오는데 실패했습니다:', error);
+    } finally {
+      setIsRankingLoading(false);
+    }
+  };
 
   // API 호출 함수들
   const onJoinClub = async (formData: ClubJoinFormData) => {
@@ -62,6 +96,19 @@ function ClubDetailPage({ user }: ClubDetailPageProps) {
           <h3 className="font-bold">설명</h3>
           <p>{club?.description}</p>
         </div>
+
+        {/* 랭킹 테이블 */}
+        {isRankingLoading ? (
+          <div className="mt-8">
+            <h3 className="font-bold mb-4">랭킹</h3>
+            <p className="text-gray-500">랭킹 데이터를 불러오는 중...</p>
+          </div>
+        ) : (
+          <RankingTable
+            attendanceRanking={rankings.attendance}
+            helperRanking={rankings.helper}
+          />
+        )}
       </div>
     </>
   );

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -19,3 +19,26 @@ export const formatToKoreanTime = (dateStr: Date) => {
 
   return `${period} ${formattedHours}:${formattedMinutes}`;
 };
+
+/**
+ * 현재 달의 시작일과 종료일을 계산하는 함수
+ * @param date - 기준 날짜 (기본값: 현재 날짜)
+ * @returns 시작일과 종료일 객체
+ */
+export const getMonthRange = (date = new Date()) => {
+  const startOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
+  const endOfMonth = new Date(
+    date.getFullYear(),
+    date.getMonth() + 1,
+    0,
+    23,
+    59,
+    59,
+    999
+  );
+
+  return {
+    startOfMonth,
+    endOfMonth,
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './classNames';
 export * from './date';
+export * from './sort';

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,20 @@
+/**
+ * 랭킹 정렬용 유틸리티 함수
+ * 카운트 기준 내림차순 정렬 후, 카운트가 동일할 경우 ID 기준 오름차순 정렬
+ * @param a - 비교할 첫 번째 객체
+ * @param b - 비교할 두 번째 객체
+ * @returns 정렬 결과값
+ */
+export const sortRankingByCountAndId = <
+  T extends { count: number; id: number },
+>(
+  a: T,
+  b: T
+): number => {
+  // 같은 카운트일 경우 ID 순으로 정렬
+  if (a.count === b.count) {
+    return a.id - b.id;
+  }
+  // 카운트 내림차순 정렬
+  return b.count - a.count;
+};


### PR DESCRIPTION
# 기획 
```
# 기획
참석, helper랭킹 기능을 추가 합니다. 
카운트 기준은 현재 달 기준으로 합니다. 

# Backend, DB 작업
* api router 추가 작업: "Workout 테이블"에서 date가 접근한 클럽 id, 현재 달에 등록된 운동을 filter, 이 filter한 운동 목록 id에 참여한 회원을 "WorkoutParticipant 테이블"에서 조회해서 반환


# frontend 작업
* 클럽 페이지에서(http://localhost:3000/clubs/1) "설명" 부분 아래 "Ranking" 필드를 추가
* 행이 3개로 하고 2행에는 attandance, 1행에는 helper을 표시
* 2행 1열은 1부터 오른차 순으로 표시 아래 markdown 참고         
* 더보기 기능: ranking 표현시 10개를 표현해주고 더보기 누르면 11번째 부터 10개씩 더보여줘 그리고 마지막에는 "접기" 버튼을 누르면 10개만 보여지게 해줘 


|   | attandance | helper |
|---|------------|--------|
| 1 |    이름     |   이름  |
| 2 |    이름     |   이름  |
| 3 |    이름     |   이름  |
         더보기
           .
           .
           .

```


# 구현 기획
```
# backend
* prisma query 에서 "_count" 이라는 필
* 백엔드에서 “*현재 달의 시작과 끝 날짜 계산” 할때  서버에서 utc 날짜로 계산해서 한국 시간과 다른지 확인하기

# frontend
* 실시간 정보가 중요한게 아님으로 react Query를 사용해서 caching 하기 
```