### PR TITLE
Feat/sort-club-member

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,7 +37,7 @@ model User {
   updatedAt           DateTime             @default(now()) @updatedAt
   
   // Relations
-  ClubMember          ClubMember[]
+  clubMember          ClubMember[]
   WorkoutParticipant  WorkoutParticipant[]
   guestPosts          GuestPost[]
   guestComments       GuestComment[]

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -8,7 +8,7 @@ model User {
   updatedAt           DateTime             @default(now()) @updatedAt
   
   // Relations
-  ClubMember          ClubMember[]
+  clubMember          ClubMember[]
   WorkoutParticipant  WorkoutParticipant[]
   guestPosts          GuestPost[]
   guestComments       GuestComment[]

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://badminton-club-community.vercel.app</loc><lastmod>2025-05-30T17:59:09.076Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://badminton-club-community.vercel.app/auth/login</loc><lastmod>2025-05-30T17:59:09.077Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://badminton-club-community.vercel.app/clubs</loc><lastmod>2025-05-30T17:59:09.077Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://badminton-club-community.vercel.app/hello</loc><lastmod>2025-05-30T17:59:09.077Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://badminton-club-community.vercel.app/members</loc><lastmod>2025-05-30T17:59:09.077Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://badminton-club-community.vercel.app/profile</loc><lastmod>2025-05-30T17:59:09.077Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://badminton-club-community.vercel.app/robots.txt</loc><lastmod>2025-05-30T17:59:09.077Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://badminton-club-community.vercel.app</loc><lastmod>2025-06-01T08:51:28.704Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://badminton-club-community.vercel.app/auth/login</loc><lastmod>2025-06-01T08:51:28.705Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://badminton-club-community.vercel.app/clubs</loc><lastmod>2025-06-01T08:51:28.705Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://badminton-club-community.vercel.app/hello</loc><lastmod>2025-06-01T08:51:28.705Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://badminton-club-community.vercel.app/members</loc><lastmod>2025-06-01T08:51:28.705Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://badminton-club-community.vercel.app/profile</loc><lastmod>2025-06-01T08:51:28.705Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://badminton-club-community.vercel.app/robots.txt</loc><lastmod>2025-06-01T08:51:28.705Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/contexts/ParticipantSortContext.tsx
+++ b/src/contexts/ParticipantSortContext.tsx
@@ -1,14 +1,14 @@
 import { createContext, useContext, ReactNode } from 'react';
 
 import { useParticipantSort } from '@/hooks/useParticipantSort';
-import { WorkoutParticipant } from '@/types';
 import { ParticipantSortState, SortOption } from '@/types/participantSort';
+import { SortableItem } from '@/types/sortable';
 
 const ParticipantSortContext = createContext<ParticipantSortState | null>(null);
 
 interface ParticipantSortProviderProps {
   children: ReactNode;
-  initialParticipants: WorkoutParticipant[];
+  initialParticipants: SortableItem[];
   initialSortOption?: SortOption;
 }
 

--- a/src/contexts/ParticipantSortContext.tsx
+++ b/src/contexts/ParticipantSortContext.tsx
@@ -2,13 +2,14 @@ import { createContext, useContext, ReactNode } from 'react';
 
 import { useParticipantSort } from '@/hooks/useParticipantSort';
 import { WorkoutParticipant } from '@/types';
-import { ParticipantSortState } from '@/types/participantSort';
+import { ParticipantSortState, SortOption } from '@/types/participantSort';
 
 const ParticipantSortContext = createContext<ParticipantSortState | null>(null);
 
 interface ParticipantSortProviderProps {
   children: ReactNode;
   initialParticipants: WorkoutParticipant[];
+  initialSortOption?: SortOption;
 }
 
 export const ParticipantSortProvider = ({

--- a/src/contexts/ParticipantSortContext.tsx
+++ b/src/contexts/ParticipantSortContext.tsx
@@ -14,8 +14,12 @@ interface ParticipantSortProviderProps {
 export const ParticipantSortProvider = ({
   children,
   initialParticipants,
+  initialSortOption,
 }: ParticipantSortProviderProps) => {
-  const sortState = useParticipantSort(initialParticipants);
+  const sortState = useParticipantSort({
+    initialParticipants,
+    initialSortOption,
+  });
 
   return (
     <ParticipantSortContext.Provider value={sortState}>

--- a/src/hooks/useParticipantSort.ts
+++ b/src/hooks/useParticipantSort.ts
@@ -50,6 +50,12 @@ export const useParticipantSort = (
             const levelB = b.clubMember?.nationalTournamentLevel || 'Z';
             return levelA.localeCompare(levelB);
           });
+        case 'birthDate':
+          return sorted.sort((a, b) => {
+            const dateA = a.clubMember?.birthDate;
+            const dateB = b.clubMember?.birthDate;
+            return dateA.localeCompare(dateB);
+          });
         default:
           return sorted;
       }

--- a/src/hooks/useParticipantSort.ts
+++ b/src/hooks/useParticipantSort.ts
@@ -8,6 +8,24 @@ interface UseParticipantSortProps {
   initialParticipants?: SortableItem[];
 }
 
+// 타입 가드 함수
+function isWorkoutParticipant(
+  item: SortableItem
+): item is SortableItem & { User: { nickname?: string } } {
+  return 'User' in item;
+}
+
+function isClubMemberWithUser(item: SortableItem): item is SortableItem & {
+  nickname: string;
+  clubMember: {
+    localTournamentLevel?: string;
+    nationalTournamentLevel?: string;
+    birthDate?: string;
+  };
+} {
+  return 'nickname' in item && 'clubMember' in item;
+}
+
 export function useParticipantSort({
   initialParticipants = [],
   initialSortOption = 'createdAt',
@@ -22,18 +40,24 @@ export function useParticipantSort({
 
       // 이름 정렬 함수 (공통으로 사용)
       const sortByName = (a: SortableItem, b: SortableItem) => {
-        const nameA = a.clubMember?.name || a?.User?.nickname || '';
-        const nameB = b.clubMember?.name || b?.User?.nickname || '';
-        return nameA.localeCompare(nameB, 'ko-KR');
+        // WorkoutParticipant인 경우
+        if (isWorkoutParticipant(a) && isWorkoutParticipant(b)) {
+          const nameA = a.User?.nickname || '';
+          const nameB = b.User?.nickname || '';
+          return nameA.localeCompare(nameB, 'ko-KR');
+        }
+        // ClubMemberWithUser인 경우
+        if (isClubMemberWithUser(a) && isClubMemberWithUser(b)) {
+          const nameA = a.nickname || '';
+          const nameB = b.nickname || '';
+          return nameA.localeCompare(nameB, 'ko-KR');
+        }
+        return 0; // 타입이 일치하지 않는 경우
       };
 
       switch (option) {
         case 'name':
-          return sorted.sort((a, b) => {
-            const nameA = a.clubMember?.name || a?.User?.nickname || '';
-            const nameB = b.clubMember?.name || b?.User?.nickname || '';
-            return nameA.localeCompare(nameB, 'ko-KR');
-          });
+          return sorted.sort(sortByName);
         case 'createdAt':
           return sorted.sort((a, b) => {
             const dateA = new Date(a.createdAt).getTime();
@@ -42,27 +66,63 @@ export function useParticipantSort({
           });
         case 'localLevel':
           return sorted.sort((a, b) => {
-            const levelA = a.clubMember?.localTournamentLevel || 'Z';
-            const levelB = b.clubMember?.localTournamentLevel || 'Z';
-            return levelA === levelB
-              ? sortByName(a, b)
-              : levelA.localeCompare(levelB);
+            // WorkoutParticipant인 경우
+            if (isWorkoutParticipant(a) && isWorkoutParticipant(b)) {
+              const levelA = a.clubMember?.localTournamentLevel || 'Z';
+              const levelB = b.clubMember?.localTournamentLevel || 'Z';
+              return levelA === levelB
+                ? sortByName(a, b)
+                : levelA.localeCompare(levelB);
+            }
+            // ClubMemberWithUser인 경우
+            if (isClubMemberWithUser(a) && isClubMemberWithUser(b)) {
+              const levelA = a.clubMember.localTournamentLevel || 'Z';
+              const levelB = b.clubMember.localTournamentLevel || 'Z';
+              return levelA === levelB
+                ? sortByName(a, b)
+                : levelA.localeCompare(levelB);
+            }
+            return 0; // 타입이 일치하지 않는 경우
           });
         case 'nationalLevel':
           return sorted.sort((a, b) => {
-            const levelA = a.clubMember?.nationalTournamentLevel || 'Z';
-            const levelB = b.clubMember?.nationalTournamentLevel || 'Z';
-            return levelA === levelB
-              ? sortByName(a, b)
-              : levelA.localeCompare(levelB);
+            // WorkoutParticipant인 경우
+            if (isWorkoutParticipant(a) && isWorkoutParticipant(b)) {
+              const levelA = a.clubMember?.nationalTournamentLevel || 'Z';
+              const levelB = b.clubMember?.nationalTournamentLevel || 'Z';
+              return levelA === levelB
+                ? sortByName(a, b)
+                : levelA.localeCompare(levelB);
+            }
+            // ClubMemberWithUser인 경우
+            if (isClubMemberWithUser(a) && isClubMemberWithUser(b)) {
+              const levelA = a.clubMember.nationalTournamentLevel || 'Z';
+              const levelB = b.clubMember.nationalTournamentLevel || 'Z';
+              return levelA === levelB
+                ? sortByName(a, b)
+                : levelA.localeCompare(levelB);
+            }
+            return 0; // 타입이 일치하지 않는 경우
           });
         case 'birthDate':
           return sorted.sort((a, b) => {
-            const dateA = a.clubMember?.birthDate || '';
-            const dateB = b.clubMember?.birthDate || '';
-            return dateA === dateB
-              ? sortByName(a, b)
-              : dateA.localeCompare(dateB);
+            // WorkoutParticipant인 경우
+            if (isWorkoutParticipant(a) && isWorkoutParticipant(b)) {
+              const dateA = a.clubMember?.birthDate || '';
+              const dateB = b.clubMember?.birthDate || '';
+              return dateA === dateB
+                ? sortByName(a, b)
+                : dateA.localeCompare(dateB);
+            }
+            // ClubMemberWithUser인 경우
+            if (isClubMemberWithUser(a) && isClubMemberWithUser(b)) {
+              const dateA = a.clubMember.birthDate || '';
+              const dateB = b.clubMember.birthDate || '';
+              return dateA === dateB
+                ? sortByName(a, b)
+                : dateA.localeCompare(dateB);
+            }
+            return 0; // 타입이 일치하지 않는 경우
           });
         default:
           return sorted;

--- a/src/hooks/useParticipantSort.ts
+++ b/src/hooks/useParticipantSort.ts
@@ -1,12 +1,18 @@
 import { useState, useCallback } from 'react';
 
 import { WorkoutParticipant } from '@/types';
-import { ParticipantSortState, SortOption } from '@/types/participantSort';
+import { SortOption } from '@/types/participantSort';
 
-export const useParticipantSort = (
-  initialParticipants: WorkoutParticipant[]
-): ParticipantSortState => {
-  const [sortOption, setSortOption] = useState<SortOption>('createdAt');
+interface UseParticipantSortProps {
+  initialSortOption?: SortOption;
+  initialParticipants?: WorkoutParticipant[];
+}
+
+export function useParticipantSort({
+  initialParticipants = [],
+  initialSortOption = 'createdAt',
+}: UseParticipantSortProps = {}) {
+  const [sortOption, setSortOption] = useState<SortOption>(initialSortOption);
   const [participants, setParticipants] =
     useState<WorkoutParticipant[]>(initialParticipants);
 
@@ -79,5 +85,6 @@ export const useParticipantSort = (
     sortOption,
     participants,
     onChangeSort,
+    setSortOption,
   };
-};
+}

--- a/src/hooks/useParticipantSort.ts
+++ b/src/hooks/useParticipantSort.ts
@@ -37,8 +37,8 @@ export const useParticipantSort = (
           });
         case 'name':
           return sorted.sort((a, b) => {
-            const nameA = a.clubMember?.name || a.User.nickname;
-            const nameB = b.clubMember?.name || b.User.nickname;
+            const nameA = a.clubMember?.name || a?.User?.nickname;
+            const nameB = b.clubMember?.name || b?.User?.nickname;
             const surnameA = nameA.charAt(0);
             const surnameB = nameB.charAt(0);
 

--- a/src/hooks/useParticipantSort.ts
+++ b/src/hooks/useParticipantSort.ts
@@ -23,44 +23,49 @@ export function useParticipantSort({
     ) => {
       const sorted = [...participantsToSort];
 
+      // 이름 정렬 함수 (공통으로 사용)
+      const sortByName = (a: WorkoutParticipant, b: WorkoutParticipant) => {
+        const nameA = a.clubMember?.name || a?.User?.nickname || '';
+        const nameB = b.clubMember?.name || b?.User?.nickname || '';
+        return nameA.localeCompare(nameB, 'ko-KR');
+      };
+
       switch (option) {
+        case 'name':
+          return sorted.sort((a, b) => {
+            const nameA = a.clubMember?.name || a?.User?.nickname || '';
+            const nameB = b.clubMember?.name || b?.User?.nickname || '';
+            return nameA.localeCompare(nameB, 'ko-KR');
+          });
         case 'createdAt':
-          return sorted.sort(
-            (a, b) =>
-              new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-          );
+          return sorted.sort((a, b) => {
+            const dateA = new Date(a.createdAt).getTime();
+            const dateB = new Date(b.createdAt).getTime();
+            return dateA === dateB ? sortByName(a, b) : dateA - dateB;
+          });
         case 'localLevel':
           return sorted.sort((a, b) => {
             const levelA = a.clubMember?.localTournamentLevel || 'Z';
             const levelB = b.clubMember?.localTournamentLevel || 'Z';
-            return levelA.localeCompare(levelB);
+            return levelA === levelB
+              ? sortByName(a, b)
+              : levelA.localeCompare(levelB);
           });
         case 'nationalLevel':
           return sorted.sort((a, b) => {
             const levelA = a.clubMember?.nationalTournamentLevel || 'Z';
             const levelB = b.clubMember?.nationalTournamentLevel || 'Z';
-            return levelA.localeCompare(levelB);
-          });
-        case 'name':
-          return sorted.sort((a, b) => {
-            const nameA = a.clubMember?.name || a?.User?.nickname;
-            const nameB = b.clubMember?.name || b?.User?.nickname;
-            const surnameA = nameA.charAt(0);
-            const surnameB = nameB.charAt(0);
-
-            if (surnameA !== surnameB) {
-              return surnameA.localeCompare(surnameB);
-            }
-
-            const levelA = a.clubMember?.nationalTournamentLevel || 'Z';
-            const levelB = b.clubMember?.nationalTournamentLevel || 'Z';
-            return levelA.localeCompare(levelB);
+            return levelA === levelB
+              ? sortByName(a, b)
+              : levelA.localeCompare(levelB);
           });
         case 'birthDate':
           return sorted.sort((a, b) => {
-            const dateA = a.clubMember?.birthDate;
-            const dateB = b.clubMember?.birthDate;
-            return dateA.localeCompare(dateB);
+            const dateA = a.clubMember?.birthDate || '';
+            const dateB = b.clubMember?.birthDate || '';
+            return dateA === dateB
+              ? sortByName(a, b)
+              : dateA.localeCompare(dateB);
           });
         default:
           return sorted;

--- a/src/hooks/useParticipantSort.ts
+++ b/src/hooks/useParticipantSort.ts
@@ -1,11 +1,11 @@
 import { useState, useCallback } from 'react';
 
-import { WorkoutParticipant } from '@/types';
 import { SortOption } from '@/types/participantSort';
+import { SortableItem } from '@/types/sortable';
 
 interface UseParticipantSortProps {
   initialSortOption?: SortOption;
-  initialParticipants?: WorkoutParticipant[];
+  initialParticipants?: SortableItem[];
 }
 
 export function useParticipantSort({
@@ -14,17 +14,14 @@ export function useParticipantSort({
 }: UseParticipantSortProps = {}) {
   const [sortOption, setSortOption] = useState<SortOption>(initialSortOption);
   const [participants, setParticipants] =
-    useState<WorkoutParticipant[]>(initialParticipants);
+    useState<SortableItem[]>(initialParticipants);
 
   const sortParticipants = useCallback(
-    (
-      option: SortOption,
-      participantsToSort: WorkoutParticipant[] = participants
-    ) => {
+    (option: SortOption, participantsToSort: SortableItem[] = participants) => {
       const sorted = [...participantsToSort];
 
       // 이름 정렬 함수 (공통으로 사용)
-      const sortByName = (a: WorkoutParticipant, b: WorkoutParticipant) => {
+      const sortByName = (a: SortableItem, b: SortableItem) => {
         const nameA = a.clubMember?.name || a?.User?.nickname || '';
         const nameB = b.clubMember?.name || b?.User?.nickname || '';
         return nameA.localeCompare(nameB, 'ko-KR');
@@ -75,7 +72,7 @@ export function useParticipantSort({
   );
 
   const onChangeSort = useCallback(
-    (option: SortOption, updatedParticipants?: WorkoutParticipant[]) => {
+    (option: SortOption, updatedParticipants?: SortableItem[]) => {
       setSortOption(option);
       if (updatedParticipants) {
         setParticipants(sortParticipants(option, updatedParticipants));

--- a/src/hooks/useParticipantSort.ts
+++ b/src/hooks/useParticipantSort.ts
@@ -11,8 +11,11 @@ export const useParticipantSort = (
     useState<WorkoutParticipant[]>(initialParticipants);
 
   const sortParticipants = useCallback(
-    (option: SortOption) => {
-      const sorted = [...participants];
+    (
+      option: SortOption,
+      participantsToSort: WorkoutParticipant[] = participants
+    ) => {
+      const sorted = [...participantsToSort];
 
       switch (option) {
         case 'createdAt':
@@ -55,9 +58,13 @@ export const useParticipantSort = (
   );
 
   const onChangeSort = useCallback(
-    (option: SortOption) => {
+    (option: SortOption, updatedParticipants?: WorkoutParticipant[]) => {
       setSortOption(option);
-      setParticipants(sortParticipants(option));
+      if (updatedParticipants) {
+        setParticipants(sortParticipants(option, updatedParticipants));
+      } else {
+        setParticipants(sortParticipants(option));
+      }
     },
     [sortParticipants]
   );

--- a/src/pages/api/clubs/members/index.ts
+++ b/src/pages/api/clubs/members/index.ts
@@ -82,26 +82,24 @@ export default async function handler(
       },
     });
 
-    // clubMember와 user 정보를 결합
-    let users = clubMembers.map((member) => ({
-      ...member.user,
-      clubMember: {
-        ...member,
-        birthDate: member.birthDate
-          ? typeof member.birthDate === 'string'
-            ? member.birthDate
-            : new Date(member.birthDate).toISOString()
-          : null,
-      },
-    }));
-
-    // JavaScript로 나이순 정렬
-    users = users.sort((a, b) => {
-      const dateA = a.clubMember.birthDate;
-      const dateB = b.clubMember.birthDate;
-      if (!dateA || !dateB) return 0;
-      return new Date(dateA).getTime() - new Date(dateB).getTime();
-    });
+    // clubMember와 user 정보를 결합하고 한글 정렬 적용
+    const users = clubMembers
+      .map((member) => ({
+        ...member.user,
+        clubMember: {
+          ...member,
+          birthDate: member.birthDate
+            ? typeof member.birthDate === 'string'
+              ? member.birthDate
+              : new Date(member.birthDate).toISOString()
+            : null,
+        },
+      }))
+      .sort((a, b) => {
+        const nameA = a.clubMember.name || '';
+        const nameB = b.clubMember.name || '';
+        return nameA.localeCompare(nameB, 'ko-KR');
+      });
 
     return res.status(200).json({
       data: {

--- a/src/pages/api/clubs/members/index.ts
+++ b/src/pages/api/clubs/members/index.ts
@@ -27,87 +27,85 @@ export default async function handler(
       });
     }
 
-    const { clubIds } = req.query;
-    if (!clubIds) {
+    const { clubId } = req.query;
+    if (!clubId) {
       return res.status(400).json({
         error: '클럽 ID가 필요합니다',
         status: 400,
       });
     }
 
-    const clubIdArray = (clubIds as string).split(',').map(Number);
+    const clubIdNumber = Number(clubId);
 
-    // 요청한 사용자가 해당 클럽들의 ADMIN인지 확인
-    const userClubRoles = await prisma.clubMember.findMany({
+    // 요청한 사용자가 해당 클럽의 ADMIN인지 확인
+    const userClubRole = await prisma.clubMember.findFirst({
       where: {
         userId: session.id,
-        clubId: { in: clubIdArray },
+        clubId: clubIdNumber,
         role: Role.ADMIN,
       },
     });
 
-    if (userClubRoles.length === 0) {
+    if (!userClubRole) {
       return res.status(403).json({
         error: '권한이 없습니다',
         status: 403,
       });
     }
 
-    // "로그인 사용자"가 여러 클럽에 속해있을 경우 모든 클럽의 멤버를 가져오기
-    //   - clubIdArray가 여러 클럽에 속할 수 있는 상황을 고려한 변수
-    //   - 예를 들어, clubIdArray가 [1, 2, 3]일 경우, 1, 2, 3 클럽의 모든 멤버를 가져오기
-    let users = await prisma.user.findMany({
+    // 클럽의 멤버를 가져오기
+    const clubMembers = await prisma.clubMember.findMany({
       where: {
-        clubMember: {
-          some: {
-            clubId: { in: clubIdArray },
-          },
-        },
+        clubId: clubIdNumber,
       },
-      include: {
-        clubMember: {
-          where: {
-            clubId: { in: clubIdArray },
-          },
+      select: {
+        status: true,
+        role: true,
+        clubId: true,
+        name: true,
+        birthDate: true,
+        localTournamentLevel: true,
+        nationalTournamentLevel: true,
+        lessonPeriod: true,
+        playingPeriod: true,
+        user: {
           select: {
-            status: true,
-            role: true,
-            clubId: true,
-            name: true,
-            birthDate: true,
-            localTournamentLevel: true,
-            nationalTournamentLevel: true,
-            lessonPeriod: true,
-            playingPeriod: true,
+            id: true,
+            kakaoId: true,
+            email: true,
+            nickname: true,
+            thumbnailImageUrl: true,
+            createdAt: true,
+            updatedAt: true,
           },
         },
       },
     });
 
-    // JavaScript로 정렬
-    users = users.sort((a, b) => {
-      const dateA = a.clubMember[0]?.birthDate;
-      const dateB = b.clubMember[0]?.birthDate;
-      if (!dateA || !dateB) return 0;
-      return new Date(dateA).getTime() - new Date(dateB).getTime();
-    });
-
-    // Date 객체를 ISO 문자열로 변환
-    const serializedUsers = users.map((user) => ({
-      ...user,
-      clubMember: user.clubMember.map((member) => ({
+    // clubMember와 user 정보를 결합
+    let users = clubMembers.map((member) => ({
+      ...member.user,
+      clubMember: {
         ...member,
         birthDate: member.birthDate
           ? typeof member.birthDate === 'string'
             ? member.birthDate
             : new Date(member.birthDate).toISOString()
           : null,
-      })),
+      },
     }));
+
+    // JavaScript로 나이순 정렬
+    users = users.sort((a, b) => {
+      const dateA = a.clubMember.birthDate;
+      const dateB = b.clubMember.birthDate;
+      if (!dateA || !dateB) return 0;
+      return new Date(dateA).getTime() - new Date(dateB).getTime();
+    });
 
     return res.status(200).json({
       data: {
-        users: serializedUsers,
+        users,
       },
       status: 200,
       message: '클럽 멤버를 불러오는데 성공했습니다',

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -56,12 +56,10 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
         if (user.id === userId) {
           return {
             ...user,
-            clubMember:
-              user.clubMember.map((member) =>
-                member.clubId === clubId
-                  ? { ...member, status: Status.APPROVED }
-                  : member
-              ) || [],
+            clubMember: {
+              ...user.clubMember,
+              status: Status.APPROVED,
+            },
           };
         }
         return user;

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -33,39 +33,9 @@ interface UsersPageContentProps {
 
 function UsersPageContent({ userClubs }: UsersPageContentProps) {
   const router = useRouter();
-  const [users, setUsers] = useState<ClubMemberWithUser[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { id: clubId } = router.query;
   const { sortOption, participants, onChangeSort } =
     useParticipantSortContext();
-
-  // 로그인 사용자가 속한 유저 조회
-  useEffect(() => {
-    const fetchUsers = async () => {
-      if (userClubs.length === 0) return;
-
-      try {
-        const clubIds = userClubs.map((club) => club.clubId).join(',');
-        const response = await fetch(`/api/clubs/members?clubIds=${clubIds}`);
-        const result = await response.json();
-        if (!response.ok) throw new Error(result.error);
-
-        setUsers(result.data.users);
-        onChangeSort('name');
-      } catch (err) {
-        console.error('사용자 데이터를 불러오는데 실패했습니다', err);
-        setError(
-          err instanceof Error
-            ? err.message
-            : '사용자 데이터를 불러오는데 실패했습니다'
-        );
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchUsers();
-  }, [userClubs]);
 
   const handleApprove = async (userId: number, clubId: number) => {
     try {
@@ -108,7 +78,6 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
   };
 
   const renderUserCard = (user: ClubMemberWithUser) => {
-    console.log(userClubs);
     return (
       <div
         key={user.id}
@@ -147,22 +116,6 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
     );
   };
 
-  if (isLoading) {
-    return (
-      <div className="flex justify-center items-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-gray-900" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex justify-center items-center min-h-screen">
-        <div className="text-red-500 bg-red-50 p-4 rounded-lg">{error}</div>
-      </div>
-    );
-  }
-
   return (
     <div className="max-w-7xl mx-auto p-6">
       <h1 className="text-2xl font-bold mb-6">클럽 멤버 관리</h1>
@@ -184,7 +137,7 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
           <div className="text-gray-600">
             총 회원 수:{' '}
             <span className="font-semibold text-gray-900">
-              {users.length}명
+              {participants.length}명
             </span>
           </div>
           <div className="relative">
@@ -228,11 +181,12 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
 }
 
 function UsersPage() {
+  const router = useRouter();
+  const { id: clubId } = router.query;
   const [users, setUsers] = useState<ClubMemberWithUser[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [userClubs, setUserClubs] = useState<ClubResponse[]>([]);
-  const router = useRouter();
 
   // 사용자가 admin권한을 가졌는지 확인
   useEffect(() => {
@@ -265,10 +219,11 @@ function UsersPage() {
   // 로그인 사용자가 속한 유저 조회
   useEffect(() => {
     const fetchUsers = async () => {
-      if (userClubs.length === 0) return;
+      if (!clubId) return;
 
       try {
-        const clubIds = userClubs.map((club) => club.clubId).join(',');
+        // const clubIds = userClubs.map((club) => club.clubId).join(',');
+        const clubIds = clubId;
         const response = await fetch(`/api/clubs/members?clubIds=${clubIds}`);
         const result = await response.json();
         if (!response.ok) throw new Error(result.error);
@@ -287,7 +242,7 @@ function UsersPage() {
     };
 
     fetchUsers();
-  }, [userClubs]);
+  }, [clubId]);
 
   if (isLoading) {
     return (

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -75,8 +75,6 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
   };
 
   const renderUserCard = (user: ClubMemberWithUser) => {
-    console.log(`🚨 ~ UsersPageContent ~ user:`, user);
-
     return (
       <div
         key={user.id}
@@ -144,6 +142,7 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
               <option value="name">이름순</option>
               <option value="localLevel">지역대회 급수</option>
               <option value="nationalLevel">전국대회 급수</option>
+              <option value="birthDate">생년월일</option>
               <option value="createdAt">가입순서</option>
             </select>
             <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -182,17 +182,23 @@ function UsersPage(/* { user }: { user: User } */) {
   return (
     <div className="max-w-7xl mx-auto p-6">
       <h1 className="text-2xl font-bold mb-6">클럽 멤버 관리</h1>
-      <div className="flex mb-2">
-        <h2 className="text-lg font-semibold mr-2">관리중인 클럽:</h2>
-        <div className="flex flex-wrap gap-2">
-          {userClubs.map((club) => (
-            <span
-              key={club.clubId}
-              className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm"
-            >
-              {club.club?.name || `클럽 ${club.clubId}`}
-            </span>
-          ))}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex mb-2">
+          <h2 className="text-lg font-semibold mr-2">관리중인 클럽:</h2>
+          <div className="flex flex-wrap gap-2">
+            {userClubs.map((club) => (
+              <span
+                key={club.clubId}
+                className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm"
+              >
+                {club.club?.name || `클럽 ${club.clubId}`}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="text-gray-600">
+          총 회원 수:{' '}
+          <span className="font-semibold text-gray-900">{users.length}명</span>
         </div>
       </div>
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -141,7 +141,9 @@ function UsersPage(/* { user }: { user: User } */) {
             />
           )}
           <h2 className="font-semibold text-lg">
-            {user.nickname || '이름 없음'}
+            {user.ClubMember.filter(
+              (member) => member.clubId === userClubs[0].clubId
+            )[0].name || '이름 없음'}
           </h2>
         </div>
         <p className="text-gray-600 text-sm mb-2">{user.email}</p>

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -15,7 +15,7 @@ import { SortOption } from '@/types/participantSort';
 import { checkClubAdminPermission } from '@/utils/permissions';
 
 interface ClubMemberWithUser extends User {
-  ClubMember: {
+  clubMember: {
     status: string;
     role: string;
     clubId: number;
@@ -56,7 +56,7 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
         if (user.id === userId) {
           return {
             ...user,
-            ClubMember: user.ClubMember.map((member) =>
+            clubMember: user.clubMember.map((member) =>
               member.clubId === clubId
                 ? { ...member, status: Status.APPROVED }
                 : member
@@ -91,13 +91,13 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
             />
           )}
           <h2 className="font-semibold text-lg">
-            {user.ClubMember.filter(
+            {user.clubMember.filter(
               (member) => member.clubId === userClubs[0].clubId
             )[0].name || '이름 없음'}
           </h2>
         </div>
         <p className="text-gray-600 text-sm mb-2">{user.email}</p>
-        {user.ClubMember.map((member) => (
+        {user.clubMember.map((member) => (
           <ClubMemberCard
             key={`${user.id}-${member.clubId}`}
             member={member}

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -14,7 +14,7 @@ import { Role, Status } from '@/types/enums';
 import { SortOption } from '@/types/participantSort';
 import { checkClubAdminPermission } from '@/utils/permissions';
 
-interface ClubMemberWithUser extends User {
+export interface ClubMemberWithUser extends User {
   clubMember: {
     status: string;
     role: string;
@@ -24,7 +24,7 @@ interface ClubMemberWithUser extends User {
     nationalTournamentLevel?: string;
     playingPeriod?: number;
     lessonPeriod?: number;
-  }[];
+  };
 }
 
 interface UsersPageContentProps {
@@ -56,11 +56,12 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
         if (user.id === userId) {
           return {
             ...user,
-            clubMember: user.clubMember.map((member) =>
-              member.clubId === clubId
-                ? { ...member, status: Status.APPROVED }
-                : member
-            ),
+            clubMember:
+              user.clubMember.map((member) =>
+                member.clubId === clubId
+                  ? { ...member, status: Status.APPROVED }
+                  : member
+              ) || [],
           };
         }
         return user;

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -12,10 +12,13 @@ import { withAuth } from '@/lib/withAuth';
 import { ClubResponse, User } from '@/types';
 import { Role, Status } from '@/types/enums';
 import { SortOption } from '@/types/participantSort';
+import { SortableItem } from '@/types/sortable';
 import { checkClubAdminPermission } from '@/utils/permissions';
 
 export interface ClubMemberWithUser extends User {
   clubMember: {
+    id: number;
+    name: string;
     status: string;
     role: string;
     clubId: number;
@@ -24,6 +27,7 @@ export interface ClubMemberWithUser extends User {
     nationalTournamentLevel?: string;
     playingPeriod?: number;
     lessonPeriod?: number;
+    helperStatuses: any[]; // HelperStatus 타입이 필요하다면 import 해서 사용
   };
 }
 
@@ -54,19 +58,20 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
       // 승인된 사용자의 상태를 업데이트
       const updatedParticipants = participants.map((user) => {
         if (user.id === userId) {
+          const updatedClubMember = {
+            ...user.clubMember,
+            status: Status.APPROVED,
+          };
           return {
             ...user,
-            clubMember: {
-              ...user.clubMember,
-              status: Status.APPROVED,
-            },
+            clubMember: updatedClubMember,
           };
         }
         return user;
       });
 
       // 정렬 옵션을 다시 적용하여 목록 업데이트
-      onChangeSort(sortOption, updatedParticipants);
+      onChangeSort(sortOption, updatedParticipants as SortableItem[]);
     } catch (err) {
       console.error('승인 처리 중 오류가 발생했습니다', err);
       throw err;

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -75,6 +75,8 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
   };
 
   const renderUserCard = (user: ClubMemberWithUser) => {
+    console.log(`🚨 ~ UsersPageContent ~ user:`, user);
+
     return (
       <div
         key={user.id}
@@ -91,21 +93,17 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
             />
           )}
           <h2 className="font-semibold text-lg">
-            {user.clubMember.filter(
-              (member) => member.clubId === userClubs[0].clubId
-            )[0].name || '이름 없음'}
+            {user.clubMember.name || '이름 없음'}
           </h2>
         </div>
         <p className="text-gray-600 text-sm mb-2">{user.email}</p>
-        {user.clubMember.map((member) => (
-          <ClubMemberCard
-            key={`${user.id}-${member.clubId}`}
-            member={member}
-            userId={user.id}
-            userClubs={userClubs}
-            onApprove={handleApprove}
-          />
-        ))}
+        <ClubMemberCard
+          key={user.id}
+          member={user.clubMember}
+          userId={user.id}
+          userClubs={userClubs}
+          onApprove={handleApprove}
+        />
         <p className="text-gray-500 text-xs mt-2">
           가입일: {new Date(user.createdAt).toLocaleDateString('ko-KR')}
         </p>
@@ -219,9 +217,7 @@ function UsersPage() {
       if (!clubId) return;
 
       try {
-        // const clubIds = userClubs.map((club) => club.clubId).join(',');
-        const clubIds = clubId;
-        const response = await fetch(`/api/clubs/members?clubIds=${clubIds}`);
+        const response = await fetch(`/api/clubs/members?clubId=${clubId}`);
         const result = await response.json();
         if (!response.ok) throw new Error(result.error);
 

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -32,8 +32,6 @@ interface UsersPageContentProps {
 }
 
 function UsersPageContent({ userClubs }: UsersPageContentProps) {
-  const router = useRouter();
-  const { id: clubId } = router.query;
   const { sortOption, participants, onChangeSort } =
     useParticipantSortContext();
 
@@ -53,27 +51,26 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
         throw new Error('승인 처리에 실패했습니다');
       }
 
-      // 사용자 목록 업데이트
-      setUsers(
-        users.map((user) => {
-          if (user.id === userId) {
-            return {
-              ...user,
-              ClubMember: user.ClubMember.map((member) =>
-                member.clubId === clubId
-                  ? { ...member, status: Status.APPROVED }
-                  : member
-              ),
-            };
-          }
-          return user;
-        })
-      );
+      // 승인된 사용자의 상태를 업데이트
+      const updatedParticipants = participants.map((user) => {
+        if (user.id === userId) {
+          return {
+            ...user,
+            ClubMember: user.ClubMember.map((member) =>
+              member.clubId === clubId
+                ? { ...member, status: Status.APPROVED }
+                : member
+            ),
+          };
+        }
+        return user;
+      });
+
+      // 정렬 옵션을 다시 적용하여 목록 업데이트
+      onChangeSort(sortOption, updatedParticipants);
     } catch (err) {
       console.error('승인 처리 중 오류가 발생했습니다', err);
-      setError(
-        err instanceof Error ? err.message : '승인 처리 중 오류가 발생했습니다'
-      );
+      throw err;
     }
   };
 

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -253,7 +253,10 @@ function UsersPage() {
   }
 
   return (
-    <ParticipantSortProvider initialParticipants={users}>
+    <ParticipantSortProvider
+      initialParticipants={users}
+      initialSortOption="name"
+    >
       <UsersPageContent userClubs={userClubs} />
     </ParticipantSortProvider>
   );

--- a/src/pages/clubs/[id]/members/index.tsx
+++ b/src/pages/clubs/[id]/members/index.tsx
@@ -167,7 +167,7 @@ function UsersPageContent({ userClubs }: UsersPageContentProps) {
       </div>
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {participants.length > 0 ? (
-          participants.map(renderUserCard)
+          participants.map((user) => renderUserCard(user as ClubMemberWithUser))
         ) : (
           <p className="col-span-full text-center text-gray-500">
             등록된 멤버가 없습니다.

--- a/src/pages/clubs/[id]/workouts/[workoutId].tsx
+++ b/src/pages/clubs/[id]/workouts/[workoutId].tsx
@@ -17,6 +17,7 @@ import mopIcon from '@/icon/mop.svg';
 import { withAuth } from '@/lib/withAuth';
 import { Workout, WorkoutParticipant, Guest } from '@/types';
 import { SortOption } from '@/types/participantSort';
+import { SortableItem } from '@/types/sortable';
 import { formatToKoreanTime } from '@/utils';
 
 type ParticipantIcons = Record<string, SelectedIcon[]>;
@@ -191,6 +192,11 @@ interface WorkoutDetailContentProps {
   ) => Promise<void>;
 }
 
+// 타입 가드 함수: 참여자 목록 정렬 조건 확인
+function isWorkoutParticipant(item: SortableItem): item is WorkoutParticipant {
+  return 'workoutId' in item && 'User' in item;
+}
+
 function WorkoutDetailContent({
   workout,
   participantIcons,
@@ -285,8 +291,11 @@ function WorkoutDetailContent({
             </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-1 sm:gap-4">
-            {participants.map((participant: WorkoutParticipant) => {
-              if (!participant.clubMember) {
+            {participants.map((participant) => {
+              if (
+                !isWorkoutParticipant(participant) ||
+                !participant.clubMember
+              ) {
                 return null;
               }
 

--- a/src/types/participantSort.ts
+++ b/src/types/participantSort.ts
@@ -1,4 +1,4 @@
-import { WorkoutParticipant } from './workout.types';
+import { SortableItem } from './sortable';
 
 export type SortOption =
   | 'createdAt'
@@ -9,9 +9,10 @@ export type SortOption =
 
 export interface ParticipantSortState {
   sortOption: SortOption;
-  participants: WorkoutParticipant[];
+  participants: SortableItem[];
   onChangeSort: (
     option: SortOption,
-    updatedParticipants?: WorkoutParticipant[]
+    updatedParticipants?: SortableItem[]
   ) => void;
+  setSortOption: (option: SortOption) => void;
 }

--- a/src/types/participantSort.ts
+++ b/src/types/participantSort.ts
@@ -1,6 +1,11 @@
 import { WorkoutParticipant } from './workout.types';
 
-export type SortOption = 'createdAt' | 'localLevel' | 'nationalLevel' | 'name';
+export type SortOption =
+  | 'createdAt'
+  | 'localLevel'
+  | 'nationalLevel'
+  | 'name'
+  | 'birthDate';
 
 export interface ParticipantSortState {
   sortOption: SortOption;

--- a/src/types/participantSort.ts
+++ b/src/types/participantSort.ts
@@ -5,5 +5,8 @@ export type SortOption = 'createdAt' | 'localLevel' | 'nationalLevel' | 'name';
 export interface ParticipantSortState {
   sortOption: SortOption;
   participants: WorkoutParticipant[];
-  onChangeSort: (option: SortOption) => void;
+  onChangeSort: (
+    option: SortOption,
+    updatedParticipants?: WorkoutParticipant[]
+  ) => void;
 }

--- a/src/types/sortable.ts
+++ b/src/types/sortable.ts
@@ -1,0 +1,9 @@
+import { ClubMemberWithUser } from '@/pages/clubs/[id]/members';
+
+import { WorkoutParticipant } from './workout.types';
+
+/**
+ * 정렬 가능한 대상의 타입
+ * WorkoutParticipant와 ClubMemberWithUser를 포함하는 유니온 타입
+ */
+export type SortableItem = WorkoutParticipant | ClubMemberWithUser;


### PR DESCRIPTION
# 제목
feat: 클럽 멤버 정렬 기능 개선 및 타입 시스템 강화

# 설명
## 변경사항
### 기능 개선
- 참여자 정렬 기능 개선 및 타입 가드 추가
- 클럽 멤버 타입 확장 및 상태 업데이트 로직 개선
- 참여자 정렬 기능에 생년월일 기준 추가

### 타입 시스템 개선
- `ClubMemberWithUser` 인터페이스 수정
- 타입 가드 함수 추가 (`isWorkoutParticipant`)
- `SortableItem` 타입 활용

### UI/UX 개선
- 클럽 멤버 카드 렌더링 로직 수정
- 총 회원수 표시 추가
- 사용자 이름 표시 로직 개선

## 테스트 방법
1. 클럽 멤버 목록 페이지 접속
2. 정렬 옵션 변경 (이름순, 지역대회 급수, 전국대회 급수, 생년월일)
3. 멤버 승인 기능 테스트

## 관련 이슈