### PR TITLE
feat: 클럽 멤버 수 조회 최적화 - APPROVED 상태 멤버만 카운트

### DIFF
--- a/src/components/organisms/navigation/clubNavigation/ClubListItem.tsx
+++ b/src/components/organisms/navigation/clubNavigation/ClubListItem.tsx
@@ -34,8 +34,8 @@ export function ClubListItem({ club }: ClubListItemProps) {
               d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
             />
           </svg>
-          {/* {club.members?.length}/{club.maxMembers}명 */}
-          {club.members?.length}명
+          {/* {club.approvedMemberCount}/{club.maxMembers}명 */}
+          {club.approvedMemberCount || 0}명
         </span>
       </div>
     </div>

--- a/src/types/club.types.ts
+++ b/src/types/club.types.ts
@@ -63,6 +63,7 @@ export interface Club extends BaseEntity {
   maxMembers: number;
   etc?: string | null;
   members?: ClubMember[];
+  approvedMemberCount?: number;
 }
 
 // 상세 정보가 포함된 클럽 타입


### PR DESCRIPTION
## �� 변경사항
클럽 목록에서 멤버 수를 표시할 때 성능 최적화를 위해 APPROVED 상태의 멤버만 카운트하도록 수정했습니다.

## �� 성능 개선
- **데이터베이스 쿼리 최적화**: 전체 ClubMember 데이터 조회 → APPROVED 상태 멤버 수만 카운트
- **메모리 사용량 감소**: 불필요한 멤버 정보 로딩 제거
- **네트워크 트래픽 감소**: API 응답 크기 대폭 감소
- **로딩 속도 향상**: 더 적은 데이터로 인한 빠른 응답

## 🔧 기술적 변경사항

### API 최적화 (`/api/clubs`)
- `include: { members: {...} }` → `include: { _count: { select: { members: { where: { status: 'APPROVED' } } } } }`
- 전체 멤버 데이터 대신 카운트만 조회

### 타입 정의 업데이트
- `Club` 인터페이스에 `approvedMemberCount?: number` 필드 추가

### 컴포넌트 수정
- `ClubListItem`에서 `club.members?.length` → `club.approvedMemberCount || 0` 사용
- 디버그용 console.log 제거

## 🧪 테스트
- [x] 클럽 목록 페이지에서 APPROVED 멤버 수 정상 표시 확인
- [x] 린터 오류 없음 확인
- [x] 타입 안정성 확인

## 📊 성능 비교
| 항목 | 이전 | 이후 |
|------|------|------|
| DB 쿼리 | 전체 멤버 조회 | 카운트만 조회 |
| 응답 크기 | 큰 객체 배열 | 숫자 값 |
| 메모리 사용량 | 높음 | 낮음 |

## 🎯 관련 이슈
- 클럽 목록 페이지 성능 최적화
- 불필요한 데이터 로딩 제거

## 📋 체크리스트
- [x] 코드 리뷰 준비 완료
- [x] 타입 정의 업데이트
- [x] API 엔드포인트 최적화
- [x] 컴포넌트 로직 수정
- [x] 린터 오류 해결
- [x] 불필요한 import 제거