### PR TITLE
feat(workout): 운동 상세에서 참가자·게스트 PersonInfo에 순번 표시 및 시간 포맷 개선

### DIFF
--- a/src/components/molecules/PersonInfo.tsx
+++ b/src/components/molecules/PersonInfo.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 
 import GuestAvatar from '@/components/atoms/GuestAvatar';
 
+import { formatToKoreanTime } from '@/utils';
 import { calculateAgeGroup } from '@/utils/age';
 
 type Gender = 'MALE' | 'FEMALE' | string;
@@ -17,6 +18,8 @@ const GENDER_DISPLAY: Record<string, string> = {
 interface PersonInfoProps {
   // 기본 인적 정보
   name: string;
+  /** 이름 앞에 표시할 순번 (예: 1, 2, 3) */
+  number?: number;
   initial?: string;
   gender?: Gender | null;
   birthDate?: string | null;
@@ -28,6 +31,8 @@ interface PersonInfoProps {
   // 급수 정보
   nationalTournamentLevel?: string | null;
   localTournamentLevel?: string | null;
+  /** 참여하기를 눌렀을 때 시각 (참여 시각 표시용) */
+  participatedAt?: string | Date | null;
   // 추가 콘텐츠
   extraIcons?: ReactNode;
   // 레이아웃/스타일 관련
@@ -43,6 +48,7 @@ interface PersonInfoProps {
 function PersonInfo({
   // 기본 인적 정보
   name,
+  number: numberProp,
   initial,
   gender,
   birthDate,
@@ -54,6 +60,7 @@ function PersonInfo({
   // 급수 정보
   nationalTournamentLevel,
   localTournamentLevel,
+  participatedAt,
   // 추가 콘텐츠
   extraIcons,
   // 레이아웃/스타일 관련
@@ -135,7 +142,12 @@ function PersonInfo({
 
       {/* 사용자 정보 */}
       <div className={`${contentClassName}`}>
-        <span className="font-medium block truncate">{name}</span>
+        <span className="font-medium block truncate">
+          {numberProp != null && (
+            <span className="text-gray-500 font-medium">{numberProp}. </span>
+          )}
+          {name}
+        </span>
 
         <div className={badgeContainerClassName}>
           {intendToJoin && (
@@ -159,6 +171,16 @@ function PersonInfo({
               title={getTournamentLevelTitle()}
             >
               {renderTournamentLevelBadge()}
+            </span>
+          )}
+          {participatedAt && (
+            <span className="text-[10px] text-gray-400 font-normal">
+              참여{' '}
+              {new Date(participatedAt).toLocaleDateString('ko-KR', {
+                month: 'numeric',
+                day: 'numeric',
+              })}{' '}
+              {formatToKoreanTime(new Date(participatedAt))}
             </span>
           )}
         </div>

--- a/src/components/molecules/PersonInfo.tsx
+++ b/src/components/molecules/PersonInfo.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 
 import GuestAvatar from '@/components/atoms/GuestAvatar';
 
-import { formatToKoreanTime } from '@/utils';
 import { calculateAgeGroup } from '@/utils/age';
 
 type Gender = 'MALE' | 'FEMALE' | string;
@@ -31,10 +30,10 @@ interface PersonInfoProps {
   // 급수 정보
   nationalTournamentLevel?: string | null;
   localTournamentLevel?: string | null;
-  /** 참여하기를 눌렀을 때 시각 (참여 시각 표시용) */
-  participatedAt?: string | Date | null;
   // 추가 콘텐츠
   extraIcons?: ReactNode;
+  /** 배지 오른쪽에 추가로 표시할 메타 정보 (예: 참여 시간) */
+  rightMeta?: ReactNode;
   // 레이아웃/스타일 관련
   className?: string;
   avatarClassName?: string;
@@ -60,14 +59,14 @@ function PersonInfo({
   // 급수 정보
   nationalTournamentLevel,
   localTournamentLevel,
-  participatedAt,
   // 추가 콘텐츠
   extraIcons,
+  rightMeta,
   // 레이아웃/스타일 관련
   className = '',
   avatarClassName = '',
   contentClassName = '',
-  badgeContainerClassName = 'flex flex-wrap gap-1 mt-1',
+  badgeContainerClassName = 'flex items-center gap-1 mt-1',
 }: PersonInfoProps) {
   // 실제 사용할 이니셜 계산
   const displayInitial = initial || name.charAt(0);
@@ -150,39 +149,33 @@ function PersonInfo({
         </span>
 
         <div className={badgeContainerClassName}>
-          {intendToJoin && (
-            <span className="inline-block bg-green-100 rounded-full px-2 py-0.5 text-xs text-green-800 font-semibold">
-              가입희망
-            </span>
-          )}
-          {gender && (
-            <span className="inline-block bg-blue-100 rounded-full px-2 py-0.5 text-xs text-gray-600">
-              {displayGender}
-            </span>
-          )}
-          {birthDate && (
-            <span className="inline-block bg-blue-100 rounded-full px-2 py-0.5 text-xs text-gray-600">
-              {calculateAgeGroup(birthDate)}
-            </span>
-          )}
-          {(nationalTournamentLevel || localTournamentLevel) && (
-            <span
-              className="inline-block bg-blue-100 rounded-full px-2 py-0.5 text-xs text-gray-600 cursor-help"
-              title={getTournamentLevelTitle()}
-            >
-              {renderTournamentLevelBadge()}
-            </span>
-          )}
-          {participatedAt && (
-            <span className="text-[10px] text-gray-400 font-normal">
-              참여{' '}
-              {new Date(participatedAt).toLocaleDateString('ko-KR', {
-                month: 'numeric',
-                day: 'numeric',
-              })}{' '}
-              {formatToKoreanTime(new Date(participatedAt))}
-            </span>
-          )}
+          <div className="flex flex-wrap gap-1">
+            {intendToJoin && (
+              <span className="inline-block bg-green-100 rounded-full px-2 py-0.5 text-xs text-green-800 font-semibold">
+                가입희망
+              </span>
+            )}
+            {gender && (
+              <span className="inline-block bg-blue-100 rounded-full px-2 py-0.5 text-xs text-gray-600">
+                {displayGender}
+              </span>
+            )}
+            {birthDate && (
+              <span className="inline-block bg-blue-100 rounded-full px-2 py-0.5 text-xs text-gray-600">
+                {calculateAgeGroup(birthDate)}
+              </span>
+            )}
+            {(nationalTournamentLevel || localTournamentLevel) && (
+              <span
+                className="inline-block bg-blue-100 rounded-full px-2 py-0.5 text-xs text-gray-600 cursor-help"
+                title={getTournamentLevelTitle()}
+              >
+                {renderTournamentLevelBadge()}
+              </span>
+            )}
+          </div>
+
+          {rightMeta && <div className="ml-auto">{rightMeta}</div>}
         </div>
         {guestRequestName && (
           <p className="text-sm text-gray-500 mt-1 text-right">

--- a/src/pages/clubs/[id]/workouts/[workoutId].tsx
+++ b/src/pages/clubs/[id]/workouts/[workoutId].tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 
+// import { useSelector } from 'react-redux';
+
 import CircleMenu, { SelectedIcon } from '@/components/molecules/CircleMenu';
 import PersonInfo from '@/components/molecules/PersonInfo';
 
@@ -18,6 +20,7 @@ import broomStickIcon from '@/icon/broomStick.svg';
 import keyIcon from '@/icon/key.svg';
 import mopIcon from '@/icon/mop.svg';
 import { withAuth } from '@/lib/withAuth';
+// import { RootState } from '@/store';
 import { Workout, WorkoutParticipant, Guest } from '@/types';
 import { SortOption } from '@/types/participantSort';
 import { SortableItem } from '@/types/sortable';
@@ -207,6 +210,9 @@ function WorkoutDetailContent({
   setSelectedParticipant,
   handleIconSelect,
 }: WorkoutDetailContentProps) {
+  // const { clubMember } = useSelector((state: RootState) => state.auth);
+  // const isAdmin = clubMember?.role === 'ADMIN';
+
   const { sortOption, participants, onChangeSort } =
     useParticipantSortContext();
   const { data: rankings = { attendance: [], helper: [] } } = useClubRankings(
@@ -394,8 +400,24 @@ function WorkoutDetailContent({
                       localTournamentLevel={
                         participant.clubMember?.localTournamentLevel
                       }
-                      participatedAt={participant.createdAt}
                       extraIcons={helperIcons}
+                      // rightMeta={
+                      //   isAdmin && participant.createdAt ? (
+                      //     <span className="text-[10px] text-gray-400 font-normal">
+                      //       참여{' '}
+                      //       {new Date(participant.createdAt).toLocaleDateString(
+                      //         'ko-KR',
+                      //         {
+                      //           month: 'numeric',
+                      //           day: 'numeric',
+                      //         }
+                      //       )}{' '}
+                      //       {formatToKoreanTime(
+                      //         new Date(participant.createdAt)
+                      //       )}
+                      //     </span>
+                      //   ) : null
+                      // }
                     />
 
                     {/* 출석 횟수와 헬퍼 활동 횟수 표시 */}

--- a/src/pages/clubs/[id]/workouts/[workoutId].tsx
+++ b/src/pages/clubs/[id]/workouts/[workoutId].tsx
@@ -264,7 +264,7 @@ function WorkoutDetailContent({
           <div className="mb-2 pt-2 sm:mb-6 sm:pt-6 border-t ">
             <h2 className="mb-2 sm:mb-4 text-xl font-semibold ">방문 게스트</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {workout.guests.map((guest: Guest) => {
+              {workout.guests.map((guest: Guest, index) => {
                 const guestRequestName = guest.clubMember?.name || '본인작성';
 
                 return (
@@ -273,6 +273,7 @@ function WorkoutDetailContent({
                     className="p-3 border rounded-lg bg-blue-50 hover:bg-blue-100 transition-colors"
                   >
                     <PersonInfo
+                      number={index + 1}
                       name={guest.name}
                       gender={guest.gender}
                       birthDate={guest.birthDate}
@@ -321,7 +322,7 @@ function WorkoutDetailContent({
             </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-1 sm:gap-4">
-            {participants.map((participant) => {
+            {participants.map((participant, index) => {
               if (
                 !isWorkoutParticipant(participant) ||
                 !participant.clubMember
@@ -378,6 +379,7 @@ function WorkoutDetailContent({
                 >
                   <div className="flex-1 relatives">
                     <PersonInfo
+                      number={index + 1}
                       name={
                         participant?.clubMember?.name ||
                         participant.User.nickname
@@ -392,6 +394,7 @@ function WorkoutDetailContent({
                       localTournamentLevel={
                         participant.clubMember?.localTournamentLevel
                       }
+                      participatedAt={participant.createdAt}
                       extraIcons={helperIcons}
                     />
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,19 +1,16 @@
 /**
- * UTC 시간을 한국 시간 형식(오후 19:30)으로 변환하는 함수
- * @param dateStr - UTC 시간 문자열 (예: "2025-02-05T19:30:00.000Z")
- * @returns 포맷팅된 시간 문자열 (예: "오후 19:30")
+ * Date를 사용자 로컬 시간 기준 한국어 12시간제(오전/오후 HH:mm)로 포맷
+ * - 서버가 UTC로 저장해도, 브라우저 로컬 타임존으로 변환된 시간을 표시
+ * @param dateInput - Date 객체 또는 파싱 가능한 날짜 값
+ * @returns 포맷 문자열 (예: "오전 01:56", "오후 07:30")
  */
-export const formatToKoreanTime = (dateStr: Date) => {
-  // UTC 시간을 파싱
-  const date = new Date(dateStr);
-  const hours = date.getUTCHours();
-  const minutes = date.getUTCMinutes();
+export const formatToKoreanTime = (dateInput: Date | string) => {
+  const date = new Date(dateInput);
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
 
-  // 12시간제로 변환
   const period = hours >= 12 ? '오후' : '오전';
   const hour12 = hours % 12 || 12;
-
-  // 시간과 분을 2자리 숫자로 포맷팅
   const formattedHours = hour12.toString().padStart(2, '0');
   const formattedMinutes = minutes.toString().padStart(2, '0');
 


### PR DESCRIPTION
### 요약
- 운동 상세(`workoutId`) 화면에서 **참가자·방문 게스트** 목록에 **순번(1., 2., …)** 을 표시합니다.
- `PersonInfo`에 **`number`**, **`rightMeta`** 슬롯을 추가해 확장 가능하게 했고, 배지 영역 레이아웃을 정리했습니다.
- **`formatToKoreanTime`** 은 **브라우저 로컬 시간** 기준으로 오전/오후를 표시하도록 바꿨고, 인자는 `Date | string` 을 받도록 했습니다.
- 관리자 전용 **참여 시각(`rightMeta`)** 표시는 **주석으로 보류**된 상태입니다.

### 변경 파일
| 파일 | 내용 |
|------|------|
| `src/components/molecules/PersonInfo.tsx` | `number`, `rightMeta` props, 배지 행 레이아웃 |
| `src/pages/clubs/[id]/workouts/[workoutId].tsx` | 게스트/참가자 `number={index + 1}` |
| `src/utils/date.ts` | `formatToKoreanTime` 로컬 시각 기준 |

### 테스트 가이드
- [ ] 운동 상세에서 참가자·게스트 이름 앞에 순번이 보이는지
- [ ] `formatToKoreanTime` 사용처에서 표시 시각이 의도한 대로인지

### 관련 커밋
- `928ae1e` — feat(workout): 참가자·게스트 PersonInfo에 순번 및 참여 시각 표시
- `f07c174` — refactor(ui): PersonInfo에 rightMeta 추가 및 참여 시각 표시는 주석으로 보류
