### PR TITLE
fix(date): 운동 시간 표시 오류 수정 (getUTCHours 복원)

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,13 +1,13 @@
 /**
- * Date를 사용자 로컬 시간 기준 한국어 12시간제(오전/오후 HH:mm)로 포맷
- * - 서버가 UTC로 저장해도, 브라우저 로컬 타임존으로 변환된 시간을 표시
- * @param dateInput - Date 객체 또는 파싱 가능한 날짜 값
- * @returns 포맷 문자열 (예: "오전 01:56", "오후 07:30")
+ * UTC 시간을 한국 시간 형식(오후 19:30)으로 변환하는 함수
+ * @param dateStr - UTC 시간 문자열 (예: "2025-02-05T19:30:00.000Z")
+ * @returns 포맷팅된 시간 문자열 (예: "오후 19:30")
  */
-export const formatToKoreanTime = (dateInput: Date | string) => {
-  const date = new Date(dateInput);
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
+export const formatToKoreanTime = (dateStr: Date) => {
+  // UTC 시간을 파싱
+  const date = new Date(dateStr);
+  const hours = date.getUTCHours();
+  const minutes = date.getUTCMinutes();
 
   const period = hours >= 12 ? '오후' : '오전';
   const hour12 = hours % 12 || 12;


### PR DESCRIPTION
## Summary
- `formatToKoreanTime`에서 `getHours()` → `getUTCHours()`로 복원
- Workout의 startTime/endTime이 DB에 한국 시간 값 그대로(예: 20:00 → `T20:00:00.000Z`) 저장되어 있어, `getHours()`(로컬 타임존 변환)를 사용하면 KST 환경에서 +9시간이 이중 적용되어 오전 5시 등 잘못된 시간이 표시되는 문제 수정

## Test plan
- [ ] 운동 목록에서 평일 운동 시간이 오후 08:00 - 오후 10:00으로 표시되는지 확인
- [ ] 주말 운동 시간이 오후 04:00 - 오후 06:00으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)