### PR TITLE
feat(guest): 게스트 신청 삭제 버튼 추가 및 관리자 전용 권한 적용

### DIFF
--- a/src/pages/api/clubs/[id]/guests/[guestId]/index.ts
+++ b/src/pages/api/clubs/[id]/guests/[guestId]/index.ts
@@ -3,6 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma';
 import { withAuth } from '@/lib/session';
 import { Role } from '@/types/enums';
+import { isVisitDatePassed } from '@/utils/date';
 
 // 게스트 신청 게시글 조회, 생성, 수정, 삭제 API
 export default withAuth(async function handler(
@@ -189,6 +190,13 @@ export default withAuth(async function handler(
           return res
             .status(403)
             .json({ message: '관리자만 삭제할 수 있습니다' });
+        }
+
+        // 방문희망일이 지난(오늘 포함) 신청은 삭제할 수 없음
+        if (isVisitDatePassed(guestPost.visitDate)) {
+          return res
+            .status(403)
+            .json({ message: '방문희망일이 지난 신청은 삭제할 수 없습니다' });
         }
 
         await prisma.guestPost.delete({

--- a/src/pages/api/clubs/[id]/guests/[guestId]/index.ts
+++ b/src/pages/api/clubs/[id]/guests/[guestId]/index.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 import { prisma } from '@/lib/prisma';
 import { withAuth } from '@/lib/session';
+import { Role } from '@/types/enums';
 
 // 게스트 신청 게시글 조회, 생성, 수정, 삭제 API
 export default withAuth(async function handler(
@@ -175,11 +176,19 @@ export default withAuth(async function handler(
     // 게스트 신청 삭제
     case 'DELETE':
       try {
-        // 해당 게시물의 작성자인지 확인
-        if (guestPost.userId !== req.user.id) {
+        // 요청한 사용자가 해당 클럽의 ADMIN인지 확인
+        const adminMember = await prisma.clubMember.findFirst({
+          where: {
+            clubId: parseInt(clubId, 10),
+            userId: req.user.id,
+            role: Role.ADMIN,
+          },
+        });
+
+        if (!adminMember) {
           return res
             .status(403)
-            .json({ message: '본인의 게시물만 삭제할 수 있습니다' });
+            .json({ message: '관리자만 삭제할 수 있습니다' });
         }
 
         await prisma.guestPost.delete({

--- a/src/pages/clubs/[id]/guest/[guestId]/index.tsx
+++ b/src/pages/clubs/[id]/guest/[guestId]/index.tsx
@@ -22,6 +22,7 @@ import { AuthProps, withAuth } from '@/lib/withAuth';
 import { RootState } from '@/store';
 import { getGuestPageStrategy } from '@/strategies/GuestPageStrategy';
 import { ClubJoinFormData } from '@/types/club.types';
+import { isVisitDatePassed } from '@/utils/date';
 
 interface Comment {
   id: string;
@@ -71,6 +72,8 @@ function GuestDetailPage({ user, guestPost }: GuestDetailPageProps) {
 
   const isAdmin = clubMember?.role === 'ADMIN'; // 관리자 여부 확인
   const isMyPost = user?.id === guestPost.userId; // 본인 게시물인지 확인
+  // 방문희망일이 지난(오늘 포함) 신청은 삭제할 수 없음
+  const isDeletable = !isVisitDatePassed(guestPost.visitDate);
 
   const [comments, setComments] = useState<Comment[]>([]); // 댓글 목록
   const [isLoading, setIsLoading] = useState(false); // 댓글 목록 처음 불러오기 중인지 여부
@@ -372,14 +375,16 @@ function GuestDetailPage({ user, guestPost }: GuestDetailPageProps) {
       >
         거절
       </Button>
-      <Button
-        onClick={onClickDeleteGuest}
-        pending={isDeleting}
-        disabled={isUpdating || isDeleting}
-        className="px-3 py-1.5 sm:px-3.5 sm:py-1.5 text-sm bg-red-500 text-white rounded-md hover:bg-red-600 disabled:opacity-50 transition-colors min-w-[60px]"
-      >
-        삭제
-      </Button>
+      {isDeletable && (
+        <Button
+          onClick={onClickDeleteGuest}
+          pending={isDeleting}
+          disabled={isUpdating || isDeleting}
+          className="px-3 py-1.5 sm:px-3.5 sm:py-1.5 text-sm bg-red-500 text-white rounded-md hover:bg-red-600 disabled:opacity-50 transition-colors min-w-[60px]"
+        >
+          삭제
+        </Button>
+      )}
     </>
   );
 

--- a/src/pages/clubs/[id]/guest/[guestId]/index.tsx
+++ b/src/pages/clubs/[id]/guest/[guestId]/index.tsx
@@ -372,6 +372,14 @@ function GuestDetailPage({ user, guestPost }: GuestDetailPageProps) {
       >
         거절
       </Button>
+      <Button
+        onClick={onClickDeleteGuest}
+        pending={isDeleting}
+        disabled={isUpdating || isDeleting}
+        className="px-3 py-1.5 sm:px-3.5 sm:py-1.5 text-sm bg-red-500 text-white rounded-md hover:bg-red-600 disabled:opacity-50 transition-colors min-w-[60px]"
+      >
+        삭제
+      </Button>
     </>
   );
 
@@ -384,14 +392,6 @@ function GuestDetailPage({ user, guestPost }: GuestDetailPageProps) {
         className="px-3 py-1.5 sm:px-3.5 sm:py-1.5 text-sm bg-blue-500 text-white rounded-md hover:bg-blue-600 disabled:opacity-50 transition-colors min-w-[60px]"
       >
         수정
-      </Button>
-      <Button
-        onClick={onClickDeleteGuest}
-        pending={isDeleting}
-        disabled={isUpdating || isDeleting}
-        className="px-3 py-1.5 sm:px-3.5 sm:py-1.5 text-sm bg-red-500 text-white rounded-md hover:bg-red-600 disabled:opacity-50 transition-colors min-w-[60px]"
-      >
-        삭제
       </Button>
     </>
   );

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -18,6 +18,27 @@ export const formatToKoreanTime = (dateStr: Date) => {
 };
 
 /**
+ * 오늘 날짜를 한국 시간(KST) 기준 'YYYY-MM-DD' 문자열로 반환하는 함수
+ * 서버(UTC)와 클라이언트(로컬 타임존)에서 동일한 값을 얻기 위해 KST 오프셋(+9h)을 직접 적용한다.
+ * @returns 'YYYY-MM-DD' 형식의 오늘 날짜 (예: "2025-02-05")
+ */
+export const getTodayInKorea = (): string => {
+  const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  return new Date(Date.now() + KST_OFFSET_MS).toISOString().split('T')[0];
+};
+
+/**
+ * 방문희망일이 지났는지(오늘 포함) 판단하는 함수
+ * visitDate는 'YYYY-MM-DD' 문자열로 저장되므로 같은 형식끼리 문자열 비교한다.
+ * @param visitDate - 방문희망일 ('YYYY-MM-DD'). 빈 값이면 지나지 않은 것으로 간주한다.
+ * @returns 방문희망일이 오늘이거나 이전이면 true
+ */
+export const isVisitDatePassed = (visitDate?: string | null): boolean => {
+  if (!visitDate) return false;
+  return visitDate <= getTodayInKorea();
+};
+
+/**
  * 현재 달의 시작일과 종료일을 계산하는 함수
  * @param date - 기준 날짜 (기본값: 현재 날짜)
  * @returns 시작일과 종료일 객체


### PR DESCRIPTION
## 개요

게스트 상세 페이지에서 게스트 신청을 삭제할 수 있는 버튼을 추가하고, 삭제 권한을 **해당 클럽의 관리자(ADMIN)** 로 제한합니다. 또한 **방문희망일이 지난(오늘 포함) 신청은 삭제할 수 없도록** 제한합니다.

## 변경 사항

### 1. 삭제 버튼 위치 이동 (`src/pages/clubs/[id]/guest/[guestId]/index.tsx`)
- 기존에는 **작성자용 버튼 그룹**(수정 옆)에 삭제 버튼이 있었음
- 이제 **관리자용 버튼 그룹**(승인/거절 옆)으로 이동
- 작성자 버튼 그룹에는 `수정`만 남음

### 2. 삭제 권한 체크 변경 (`src/pages/api/clubs/[id]/guests/[guestId]/index.ts`)
| 구분 | 변경 전 | 변경 후 |
|---|---|---|
| 권한 조건 | 게시물 작성자 본인 (`guestPost.userId === req.user.id`) | 해당 클럽의 `ADMIN` 멤버 |
| 조회 방식 | 추가 조회 없음 | `clubMember`에서 `clubId` + `userId` + `role: ADMIN` 조회 |
| 403 메시지 | `본인의 게시물만 삭제할 수 있습니다` | `관리자만 삭제할 수 있습니다` |

### 3. 방문희망일 경과 시 삭제 제한
`visitDate`는 `YYYY-MM-DD` 문자열로 저장되므로, 같은 형식의 오늘 날짜와 문자열 비교합니다.

| 위치 | 동작 |
|---|---|
| `src/utils/date.ts` | `getTodayInKorea()`, `isVisitDatePassed()` 유틸 추가 |
| 상세 페이지 UI | `visitDate <= 오늘`이면 `삭제` 버튼 미노출 |
| `DELETE` API | 동일 조건일 때 403 `방문희망일이 지난 신청은 삭제할 수 없습니다` 반환 |

**KST 기준 처리**: 서버는 UTC, 클라이언트는 로컬 타임존이라 `new Date().toISOString()`을 그대로 쓰면 KST 00:00~09:00 구간에서 하루가 밀립니다. 이를 피하기 위해 `getTodayInKorea()`에서 +9h 오프셋을 명시적으로 적용해 서버/클라이언트가 항상 같은 날짜를 계산하도록 했습니다.

## 판정 기준
| visitDate | 삭제 버튼 |
|---|---|
| 어제 이전 | 미노출 |
| 오늘 | 미노출 |
| 내일 이후 | 노출 |
| 빈 값 | 노출 (경과하지 않은 것으로 간주) |

## 검증
- `npx tsc --noEmit`: 변경으로 인한 신규 에러 없음 (기존 `sms-notification.test.ts` 에러 13건은 base 커밋에도 동일하게 존재)
- `next lint` (변경 파일 3개): `No ESLint warnings or errors`
- KST 자정 경계(2026-08-15 16:00 UTC = 2026-08-16 01:00 KST) 케이스에서 날짜 판정이 의도대로 동작하는 것 확인

## 테스트 포인트
- [ ] 관리자 계정: 방문희망일이 미래인 신청에서 승인/거절 옆에 `삭제` 버튼 노출 및 정상 동작
- [ ] 관리자 계정: 방문희망일이 오늘이거나 지난 신청에서 `삭제` 버튼 미노출
- [ ] 삭제 API 직접 호출 시 — 비관리자 403, 방문희망일 경과 건 403
- [ ] 일반(작성자) 계정: `수정` 버튼만 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)