### PR TITLE
fix(ui): 긴 URL이 본문 박스를 넘치지 않도록 줄바꿈 처리

### DIFF
--- a/src/components/molecules/ClubInfoSection.tsx
+++ b/src/components/molecules/ClubInfoSection.tsx
@@ -11,7 +11,7 @@ export function ClubInfoSection({ title, content }: ClubInfoSectionProps) {
   return (
     <div className="mb-6">
       <h2 className="text-xl font-semibold mb-2">{title}</h2>
-      <p className="text-gray-700 whitespace-pre-wrap">{content}</p>
+      <p className="text-gray-700 whitespace-pre-wrap break-words">{content}</p>
     </div>
   );
 }

--- a/src/components/molecules/board/CommentItem.tsx
+++ b/src/components/molecules/board/CommentItem.tsx
@@ -222,7 +222,7 @@ function CommentItem({ comment, clubId, postId, depth = 0 }: CommentItemProps) {
           </div>
         ) : (
           <>
-            <p className="text-gray-700 whitespace-pre-wrap mb-2">
+            <p className="text-gray-700 whitespace-pre-wrap break-words mb-2">
               {comment.content}
             </p>
             <div className="flex items-center gap-3">

--- a/src/components/organisms/board/PostDetail.tsx
+++ b/src/components/organisms/board/PostDetail.tsx
@@ -142,7 +142,7 @@ function PostDetail({ post }: PostDetailProps) {
 
       {/* 내용 */}
       <div className="prose max-w-none mb-6">
-        <div className="whitespace-pre-wrap text-gray-700">
+        <div className="whitespace-pre-wrap break-words text-gray-700">
           {renderContentWithLinks(post.content)}
         </div>
       </div>

--- a/src/components/organisms/comment/CommentItem.tsx
+++ b/src/components/organisms/comment/CommentItem.tsx
@@ -118,7 +118,9 @@ export function CommentItem({
           </div>
         </div>
       ) : (
-        <p className="text-gray-700 whitespace-pre-wrap">{content}</p>
+        <p className="text-gray-700 whitespace-pre-wrap break-words">
+          {content}
+        </p>
       )}
     </div>
   );

--- a/src/components/organisms/tournament/entry/ApplyNotice.tsx
+++ b/src/components/organisms/tournament/entry/ApplyNotice.tsx
@@ -16,7 +16,7 @@ function ApplyNotice({ notice }: ApplyNoticeProps) {
       <h2 className="text-sm font-semibold text-amber-900">
         신청 전 확인해주세요
       </h2>
-      <p className="mt-1 whitespace-pre-wrap text-sm text-amber-900">
+      <p className="mt-1 whitespace-pre-wrap break-words text-sm text-amber-900">
         {renderContentWithLinks(notice)}
       </p>
     </section>

--- a/src/pages/clubs/[id]/guest/[guestId]/index.tsx
+++ b/src/pages/clubs/[id]/guest/[guestId]/index.tsx
@@ -476,7 +476,7 @@ function GuestDetailPage({ user, guestPost }: GuestDetailPageProps) {
           {/* 신청 메시지 섹션 */}
           <InfoSection title={strategy.getDetailPageMessageTitle()} fullWidth>
             <div className="bg-white p-3 rounded-md">
-              <p className="text-gray-700 whitespace-pre-wrap">
+              <p className="text-gray-700 whitespace-pre-wrap break-words">
                 {guestPost.message || '작성된 메시지가 없습니다.'}
               </p>
             </div>

--- a/src/pages/clubs/[id]/guest/index.tsx
+++ b/src/pages/clubs/[id]/guest/index.tsx
@@ -230,7 +230,7 @@ function GuestPage({ user }: AuthProps) {
       <div className="bg-white rounded-lg shadow p-3 sm:p-6">
         <h1 className="text-2xl font-bold mb-4">{strategy.getPageTitle()}</h1>
 
-        <p className="text-gray-600 mb-6 whitespace-pre-wrap">
+        <p className="text-gray-600 mb-6 whitespace-pre-wrap break-words">
           {strategy.getDescription()}
         </p>
 

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/index.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/index.tsx
@@ -74,7 +74,7 @@ function TournamentDetailPage() {
       {tournament.description && (
         <section>
           <h2 className="mb-2 font-semibold">모집 요강</h2>
-          <p className="whitespace-pre-wrap rounded-lg bg-gray-50 p-4 text-sm text-gray-700">
+          <p className="whitespace-pre-wrap break-words rounded-lg bg-gray-50 p-4 text-sm text-gray-700">
             {renderContentWithLinks(tournament.description)}
           </p>
         </section>


### PR DESCRIPTION
## 문제

대회 모집 요강에 긴 URL을 넣으면 회색 박스의 오른쪽 경계를 넘어 글자가 잘렸습니다.

모바일에서 `https://mazerasports.com/product/...` 링크가 박스 밖으로 삐져나가
`.../category/1/display/3/?` 부분이 화면 오른쪽에서 잘렸습니다.

## 원인

링크(`<a>`)에는 `break-all`이 있었지만, **컨테이너에는 `whitespace-pre-wrap`만** 있었습니다.

`whitespace-pre-wrap`은 공백을 보존하는 모드라, 공백이 하나도 없는 긴 URL은
줄을 바꿀 지점을 찾지 못하고 컨테이너 밖으로 밀려납니다.

## 수정

컨테이너에 `break-words`(`overflow-wrap: break-word`)를 추가했습니다.
이 저장소가 이미 `TournamentCard`, `EntryTable`에서 쓰던 방식과 동일합니다.

**같은 구조를 쓰는 8곳 전부**에 적용했습니다. 지금 고치지 않으면 동일하게 깨질 자리입니다.

| 커밋 | 대상 |
|---|---|
| `fffc4bc` | 대회 모집 요강(신고된 곳), 게시글 본문, 신청 주의사항 |
| `c495fb0` | 클럽 소개, 댓글 2곳, 게스트 목록·상세 |

이제 `whitespace-pre-wrap`을 쓰는 모든 곳이 `break-words`를 함께 갖습니다.

## 검증

| 항목 | 결과 |
|---|---|
| `jest` (src) | 191 passed |
| `tsc --noEmit` | 이번 변경 관련 에러 없음 |
| `eslint` / `prettier` | 통과 |
| 빌드 CSS | `.break-words{overflow-wrap:break-word}` 생성 확인 |

CSS 클래스 추가만 있고 로직 변경은 없습니다.

### 남은 확인

이 환경에 브라우저 자동화 도구가 없어 **픽셀 단위로 "넘침이 사라졌다"를 측정하지는 못했습니다.**
CSS 규칙 적용과 원인–처방의 대응은 확실하나, 실제 화면에서 한 번 확인 부탁드립니다.

### 알려진 기존 실패 (이번 변경과 무관)

`sms-notification.test.ts`, `GuestPageStrategy.test.ts` 2개 suite(16 tests)는
이번 작업 이전부터 동일하게 실패하던 것입니다.
