### PR TITLE
fix(board): 게시글 제목·본문의 긴 문자열이 카드를 넘치지 않도록 수정

### DIFF
--- a/src/components/organisms/board/PostCard.tsx
+++ b/src/components/organisms/board/PostCard.tsx
@@ -21,18 +21,18 @@ function PostCard({ post }: PostCardProps) {
       onClick={onClickPost}
     >
       <div className="flex items-start justify-between mb-2">
-        <div className="flex-1">
+        <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 mb-2">
             {post.isPinned && (
-              <span className="text-blue-500" title="고정 게시글">
+              <span className="shrink-0 text-blue-500" title="고정 게시글">
                 📌
               </span>
             )}
-            <h2 className="font-semibold text-lg sm:text-xl text-gray-900 line-clamp-2">
+            <h2 className="min-w-0 font-semibold text-lg sm:text-xl text-gray-900 line-clamp-2 break-words">
               {post.title}
             </h2>
           </div>
-          <p className="text-gray-600 text-sm sm:text-base line-clamp-2 mb-3">
+          <p className="text-gray-600 text-sm sm:text-base line-clamp-2 break-words mb-3">
             {post.content}
           </p>
         </div>

--- a/src/components/organisms/board/PostDetail.tsx
+++ b/src/components/organisms/board/PostDetail.tsx
@@ -116,14 +116,14 @@ function PostDetail({ post }: PostDetailProps) {
     <div className="bg-white rounded-lg shadow p-4 sm:p-6">
       {/* 헤더 */}
       <div className="flex items-start justify-between mb-4">
-        <div className="flex-1">
+        <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 mb-2">
             {post.isPinned && (
-              <span className="text-blue-500" title="고정 게시글">
+              <span className="shrink-0 text-blue-500" title="고정 게시글">
                 📌
               </span>
             )}
-            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">
+            <h1 className="min-w-0 break-words text-2xl sm:text-3xl font-bold text-gray-900">
               {post.title}
             </h1>
           </div>


### PR DESCRIPTION
## 문제

게시판 목록(`/clubs/1/board`)에서 공백 없는 긴 URL이 카드의 오른쪽 경계를 넘어 잘렸습니다.

실제 데이터로 재현되는 게시글이 있습니다.

| 게시글 | 최장 연속 문자열 |
| --- | --- |
| `cmkw4ww92...` | 89자 — `https://www.notion.so/1baaf6a55f51...` |
| `cmkse1zff...` | 66자 — `https://www.notion.so/happyjy0109/...` |
| `cmm8md9o9...` | 63자 — `---...` 구분선 |

## 원인

앞선 PR #57(`whitespace-pre-wrap` + `break-words`)과는 **다른 원인**입니다.

flex 자식은 기본값이 `min-width: auto`라 **콘텐츠 최소 폭보다 작아지지 못합니다.**
공백 없는 긴 문자열은 그 자체가 하나의 큰 최소 폭이 되어 부모를 밀어냅니다.

```jsx
<div className="flex ...">
  <div className="flex-1">        {/* min-width:auto → 콘텐츠에 밀려 넘침 */}
    <h2 className="line-clamp-2">{post.title}</h2>
  </div>
</div>
```

`line-clamp-2`는 **세로 줄 수만 제한**할 뿐 가로 넘침은 막지 못합니다.

## 수정

```jsx
<div className="min-w-0 flex-1">   {/* 콘텐츠 아래로 줄어들 수 있게 */}
  <h2 className="min-w-0 line-clamp-2 break-words">{post.title}</h2>
</div>
```

| 클래스 | 역할 |
| --- | --- |
| `min-w-0` | flex 자식이 콘텐츠보다 작아질 수 있게 (넘침의 근본 원인 해소) |
| `break-words` | 긴 문자열을 박스 안에서 접음 |
| `shrink-0` | 📌 고정 아이콘이 찌그러지지 않게 |

적용 위치: `PostCard`(목록 제목·본문), `PostDetail`(상세 제목)

## 검증

| 항목 | 결과 |
| --- | --- |
| `jest` (src) | 191 passed |
| `tsc --noEmit` | 이번 변경 관련 에러 없음 |
| `eslint` / `prettier` | 통과 |
| 빌드 CSS | `.min-w-0{min-width:0}` · `.shrink-0{flex-shrink:0}` · `.break-words{overflow-wrap:break-word}` 생성 확인 |

CSS 클래스 추가만 있고 로직 변경은 없습니다.

### 남은 확인

브라우저 자동화 도구가 없어 **픽셀 단위로 넘침이 사라졌는지는 측정하지 못했습니다.**
CSS 규칙 생성과 원인–처방의 대응은 확인했으나, 실제 화면 확인 부탁드립니다.

### 알려진 기존 실패 (이번 변경과 무관)

`sms-notification.test.ts`, `GuestPageStrategy.test.ts` 2개 suite(16 tests)는 이전부터 실패하던 것입니다.