### PR TITLE
feat(join): 생년월일·방문 날짜를 date 입력으로 변경

### DIFF
--- a/src/components/organisms/modal/join/JoinModal.tsx
+++ b/src/components/organisms/modal/join/JoinModal.tsx
@@ -82,18 +82,6 @@ function JoinModal({
   const getFullPhoneNumber = () =>
     `${phoneNumbers.first}-${phoneNumbers.second}-${phoneNumbers.third}`;
 
-  // 날짜 변환 헬퍼 함수
-  const parseDate = (dateString: string): Date | null => {
-    if (!dateString) return null;
-    const date = new Date(dateString);
-    return isNaN(date.getTime()) ? null : date;
-  };
-
-  const formatDate = (date: Date | null): string => {
-    if (!date) return '';
-    return date.toISOString().split('T')[0];
-  };
-
   // 날짜 범위 설정
   const today = new Date();
   const minBirthDate = new Date(1950, 0, 1);
@@ -175,8 +163,6 @@ function JoinModal({
     checkPhoneVerificationStatus,
     sendPhoneVerificationCode,
     verifyPhoneCode,
-    parseDate,
-    formatDate,
     minBirthDate,
     maxBirthDate,
     minVisitDate,

--- a/src/components/organisms/modal/join/JoinModalContext.tsx
+++ b/src/components/organisms/modal/join/JoinModalContext.tsx
@@ -41,8 +41,6 @@ export interface JoinModalContextType {
   verifyPhoneCode?: (phoneNumber: string, code: string) => Promise<any>;
 
   // 날짜 관련 유틸
-  parseDate: (dateString: string) => Date | null;
-  formatDate: (date: Date | null) => string;
 
   // 날짜 범위
   minBirthDate: Date;

--- a/src/components/organisms/modal/join/components/fields/BirthDateField.tsx
+++ b/src/components/organisms/modal/join/components/fields/BirthDateField.tsx
@@ -1,44 +1,26 @@
 import React from 'react';
 
-import CustomDatePicker from '@/components/atoms/inputs/DatePicker';
+import { Input } from '@/components/atoms/inputs/Input';
 import { FormField } from '@/components/molecules/form/FormField';
+
+import { toLocalDateString } from '@/utils/date';
 
 import { useJoinModalContext } from '../../JoinModalContext';
 
 function BirthDateField() {
-  const {
-    formData,
-    onChangeInput,
-    parseDate,
-    formatDate,
-    minBirthDate,
-    maxBirthDate,
-  } = useJoinModalContext();
-
-  const handleChange = (date: Date | null) => {
-    const event = {
-      target: {
-        name: 'birthDate',
-        value: formatDate(date),
-      },
-    } as React.ChangeEvent<HTMLInputElement>;
-    onChangeInput(event);
-  };
+  const { formData, onChangeInput, minBirthDate, maxBirthDate } =
+    useJoinModalContext();
 
   return (
     <FormField label="생년월일" required>
-      <CustomDatePicker
-        selected={parseDate(formData.birthDate || '')}
-        onChange={handleChange}
-        placeholderText="생년월일을 선택하세요"
+      <Input
+        type="date"
+        name="birthDate"
+        value={formData.birthDate || ''}
+        onChange={onChangeInput}
         required
-        minDate={minBirthDate}
-        maxDate={maxBirthDate}
-        showYearDropdown
-        showMonthDropdown
-        dropdownMode="select"
-        yearDropdownItemNumber={50}
-        scrollableYearDropdown
+        min={toLocalDateString(minBirthDate)}
+        max={toLocalDateString(maxBirthDate)}
       />
     </FormField>
   );

--- a/src/components/organisms/modal/join/components/fields/VisitDateField.tsx
+++ b/src/components/organisms/modal/join/components/fields/VisitDateField.tsx
@@ -1,44 +1,26 @@
 import React from 'react';
 
-import CustomDatePicker from '@/components/atoms/inputs/DatePicker';
+import { Input } from '@/components/atoms/inputs/Input';
 import { FormField } from '@/components/molecules/form/FormField';
+
+import { toLocalDateString } from '@/utils/date';
 
 import { useJoinModalContext } from '../../JoinModalContext';
 
 function VisitDateField() {
-  const {
-    formData,
-    onChangeInput,
-    parseDate,
-    formatDate,
-    minVisitDate,
-    maxVisitDate,
-  } = useJoinModalContext();
-
-  const handleChange = (date: Date | null) => {
-    const event = {
-      target: {
-        name: 'visitDate',
-        value: formatDate(date),
-      },
-    } as React.ChangeEvent<HTMLInputElement>;
-    onChangeInput(event);
-  };
+  const { formData, onChangeInput, minVisitDate, maxVisitDate } =
+    useJoinModalContext();
 
   return (
     <FormField label="방문 날짜" required>
-      <CustomDatePicker
-        selected={parseDate(formData.visitDate || '')}
-        onChange={handleChange}
-        placeholderText="방문 날짜를 선택하세요"
+      <Input
+        type="date"
+        name="visitDate"
+        value={formData.visitDate || ''}
+        onChange={onChangeInput}
         required
-        minDate={minVisitDate}
-        maxDate={maxVisitDate}
-        showYearDropdown
-        showMonthDropdown
-        dropdownMode="select"
-        yearDropdownItemNumber={5}
-        scrollableYearDropdown
+        min={toLocalDateString(minVisitDate)}
+        max={toLocalDateString(maxVisitDate)}
       />
     </FormField>
   );

--- a/src/utils/__tests__/toLocalDateString.test.ts
+++ b/src/utils/__tests__/toLocalDateString.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { toLocalDateString } from '../date';
+
+describe('toLocalDateString', () => {
+  it('로컬 날짜를 YYYY-MM-DD로 변환한다', () => {
+    expect(toLocalDateString(new Date(2026, 7, 17))).toBe('2026-08-17');
+  });
+
+  it('월·일을 두 자리로 채운다', () => {
+    expect(toLocalDateString(new Date(2026, 0, 5))).toBe('2026-01-05');
+  });
+
+  // toISOString()을 쓰면 UTC로 밀려 "2026-08-16"이 되던 케이스
+  it('자정 직후에도 날짜가 하루 밀리지 않는다', () => {
+    expect(toLocalDateString(new Date(2026, 7, 17, 0, 30))).toBe('2026-08-17');
+  });
+
+  it('하루의 끝에도 날짜가 넘어가지 않는다', () => {
+    expect(toLocalDateString(new Date(2026, 7, 17, 23, 59))).toBe('2026-08-17');
+  });
+
+  it('과거 연도도 그대로 변환한다', () => {
+    expect(toLocalDateString(new Date(1950, 0, 1))).toBe('1950-01-01');
+  });
+
+  it('null이면 빈 문자열', () => {
+    expect(toLocalDateString(null)).toBe('');
+  });
+
+  it('유효하지 않은 Date면 빈 문자열', () => {
+    expect(toLocalDateString(new Date('invalid'))).toBe('');
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -28,6 +28,23 @@ export const getTodayInKorea = (): string => {
 };
 
 /**
+ * Date를 로컬 시간 기준 'YYYY-MM-DD' 문자열로 변환하는 함수
+ * toISOString()은 UTC로 변환하므로 KST에서는 날짜가 하루 밀린다.
+ * (예: 2026-08-17 00:30 KST -> "2026-08-16")
+ * input[type=date]의 value·min·max처럼 사용자가 보는 날짜와
+ * 정확히 일치해야 하는 곳에 쓴다.
+ * @param date - 변환할 Date. null이면 빈 문자열을 반환한다.
+ * @returns 'YYYY-MM-DD' 형식 문자열 (예: "2026-08-17")
+ */
+export const toLocalDateString = (date: Date | null): string => {
+  if (!date || isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/**
  * 방문희망일이 지났는지(오늘 포함) 판단하는 함수
  * visitDate는 'YYYY-MM-DD' 문자열로 저장되므로 같은 형식끼리 문자열 비교한다.
  * @param visitDate - 방문희망일 ('YYYY-MM-DD'). 빈 값이면 지나지 않은 것으로 간주한다.


### PR DESCRIPTION
## 개요

게스트 신청·문의, 모임 가입 신청의 날짜 입력을 대회 폼과 같은 `input[type=date]`로 통일합니다.

```jsx
<FormField label="대회 일자">
  <Input type="date" {...methods.register('tournamentDate')} />
</FormField>
```

기존에는 `react-datepicker` 기반 커스텀 컴포넌트를 썼습니다.
브라우저 기본 달력으로 바꾸면 모바일에서 네이티브 날짜 선택 UI가 뜨고, 직접 타이핑도 가능합니다.

## 적용 범위

`BirthDateField` / `VisitDateField` 두 파일만 고치면 세 모달에 모두 반영됩니다.

| 모달 | 생년월일 | 방문 날짜 |
| --- | :---: | :---: |
| 게스트 신청 | ✅ | ✅ |
| 게스트 문의 | ✅ | ✅ |
| 모임 가입 신청 | ✅ | — |

## 함께 고친 시간대 버그

작업 중 `JoinModal`의 `formatDate`에서 버그를 발견했습니다.

```js
const formatDate = (date) => date.toISOString().split('T')[0];
```

`toISOString()`은 UTC로 변환하므로 **KST 기준 날짜가 하루 밀립니다.**

| 로컬(KST) 값 | 기존 결과 | 기대값 |
| --- | --- | --- |
| 2026-08-17 00:30 | `2026-08-16` ❌ | `2026-08-17` |
| 오늘(`maxBirthDate`) | 하루 전 ❌ | 오늘 |

기존 `DatePicker`는 `Date` 객체를 직접 받아 이 버그가 드러나지 않았지만,
`input[type=date]`의 `min`/`max`는 **문자열**이라 그대로 노출됩니다.
그대로 뒀다면 **오늘이 생일인 사람이 오늘 날짜를 선택하지 못합니다.**

로컬 시간 기준 `toLocalDateString()`을 `src/utils/date.ts`에 추가해 사용합니다.
(이 저장소가 이미 `getTodayInKorea()`로 시간대를 명시 처리하던 관행을 따랐습니다.)

## 정리한 코드

교체 후 소비처가 사라진 `JoinModal`의 `parseDate` / `formatDate`와 컨텍스트 타입을 제거했습니다.
특히 버그가 있는 `formatDate`를 남겨두면 다시 쓰일 위험이 있어 함께 지웠습니다.

## 호환성

저장 형식은 `'YYYY-MM-DD'`로 **기존과 동일**합니다. API·DB 변경이 없습니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| `jest` (src) | **198 passed** (191 → +7) |
| 신규 테스트 | `toLocalDateString` 7개 (자정 직후·연말 경계·null·Invalid Date) |
| `tsc --noEmit` | 이번 변경 관련 에러 없음 |
| `eslint` / `prettier` | 통과 |
| `next build` | 성공 |

### 남은 확인

브라우저 자동화 도구가 없어 **실제 달력 UI 동작은 육안 확인을 하지 못했습니다.**
로직·타입·빌드는 확인했으니, 모바일에서 네이티브 달력이 뜨는지 한 번 봐주세요.

### 알려진 기존 실패 (이번 변경과 무관)

`sms-notification.test.ts`, `GuestPageStrategy.test.ts` 2개 suite(16 tests)는 이전부터 실패하던 것입니다.