### PR TITLE
fix(tournament): 신청 취소 후 버튼을 '다시 신청하기'로 표시

### DIFF
--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/index.ts
@@ -47,7 +47,7 @@ export default withAuth(async function handler(
 
       const myEntry = await prisma.tournamentEntry.findUnique({
         where: { tournamentId_userId: { tournamentId, userId: req.user.id } },
-        select: { id: true },
+        select: { id: true, paymentStatus: true },
       });
 
       return res.status(200).json({
@@ -55,6 +55,7 @@ export default withAuth(async function handler(
           tournament,
           effectiveStatus,
           myEntryId: myEntry?.id ?? null,
+          myEntryPaymentStatus: myEntry?.paymentStatus ?? null,
         },
         message: '대회 정보를 불러왔습니다.',
       });

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/index.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/index.tsx
@@ -31,8 +31,16 @@ function TournamentDetailPage() {
     );
   }
 
-  const { tournament, effectiveStatus, myEntryId } = detail;
+  const { tournament, effectiveStatus, myEntryId, myEntryPaymentStatus } =
+    detail;
   const basePath = `/clubs/${clubId}/tournaments/${tournamentId}`;
+  // 전체 취소된 신청서는 수정이 아니라 재신청으로 안내한다
+  const isEntryCanceled = myEntryPaymentStatus === 'CANCELED';
+  const applyButtonLabel = !myEntryId
+    ? '신청하기'
+    : isEntryCanceled
+      ? '다시 신청하기'
+      : '신청 내용 수정';
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-4 sm:p-6">
@@ -128,7 +136,7 @@ function TournamentDetailPage() {
             onClick={() => router.push(`${basePath}/apply`)}
             className="w-full rounded-md bg-blue-600 py-3 font-medium text-white"
           >
-            {myEntryId ? '신청 내용 수정' : '신청하기'}
+            {applyButtonLabel}
           </button>
         )}
         {myEntryId && (

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/my.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/my.tsx
@@ -169,7 +169,9 @@ function MyEntryPage() {
           }
           className="w-full rounded-md border border-blue-600 py-3 font-medium text-blue-600"
         >
-          신청 내용 수정
+          {myEntry.paymentStatus === 'CANCELED'
+            ? '다시 신청하기'
+            : '신청 내용 수정'}
         </button>
       ) : (
         <p className="text-center text-sm text-gray-500">

--- a/src/types/tournament.types.ts
+++ b/src/types/tournament.types.ts
@@ -102,4 +102,5 @@ export interface TournamentDetailResponse {
   tournament: TournamentWithOptions;
   effectiveStatus: TournamentEffectiveStatus;
   myEntryId: string | null;
+  myEntryPaymentStatus: EntryPaymentStatus | null;
 }


### PR DESCRIPTION
## 문제

대회 신청을 전체 취소한 뒤에도 대회 상세·내 신청 내역 화면에 **'신청 내용 수정'** 버튼이 그대로 노출됐습니다. 이미 취소된 신청서라 실제로는 재신청 흐름인데, 라벨만 보면 알 수 없었습니다.

원인은 대회 상세 API가 `myEntryId`만 내려주고 취소 여부를 알려주지 않아, 화면에서 "신청서 존재 여부"만으로 라벨을 정하고 있었기 때문입니다.

## 변경 사항

| 파일 | 변경 |
|---|---|
| `api/.../tournaments/[tournamentId]/index.ts` | `select`에 `paymentStatus` 추가, 응답에 `myEntryPaymentStatus` 반환 |
| `types/tournament.types.ts` | `TournamentDetailResponse`에 `myEntryPaymentStatus` 추가 |
| `clubs/[id]/tournaments/[tournamentId]/index.tsx` | `applyButtonLabel`로 3분기 분리 |
| `clubs/[id]/tournaments/[tournamentId]/my.tsx` | 동일한 문제가 있어 함께 수정 |

버튼 라벨 로직:

```
myEntryId 없음                  → 신청하기
paymentStatus === 'CANCELED'    → 다시 신청하기
그 외                           → 신청 내용 수정
```

기존 백엔드 동작과 그대로 맞물립니다. 전체 종목 취소 시 `paymentStatus`가 `CANCELED`가 되고(`lib/tournament/cancel.ts`), '다시 신청하기'로 들어가 저장하면 `PENDING`으로 복구됩니다(`entries/[entryId]/index.ts`). API 필드 추가 외에 동작 변경은 없습니다.

## 검증

- `npx tsc --noEmit` — 변경한 4개 파일에 에러 없음
- ⚠️ **테스트 미실행**: `jest-environment-jsdom` 모듈이 없어 테스트가 실행되지 않습니다. 이 브랜치와 무관한 기존 문제로, clean tree에서도 동일하게 재현됩니다. (`src/lib/sms-notification.test.ts`의 타입 에러 13건도 기존 이슈입니다)
- ⚠️ 브라우저에서 실제 취소 → 상세 페이지 진입 후 라벨 확인은 아직 못 했습니다. 리뷰 시 확인 부탁드립니다.