### PR TITLE
fix(tournament): 선수 전화번호 형식 검증 추가

### DIFF
--- a/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
+++ b/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
@@ -58,6 +58,13 @@ function getBirthDateInput(index = 0): HTMLInputElement {
   ] as HTMLInputElement;
 }
 
+/** n번째 선수의 전화번호 입력창을 가져온다. */
+function getPhoneNumberInput(index = 0): HTMLInputElement {
+  return screen.getAllByPlaceholderText('010-1234-5678')[
+    index
+  ] as HTMLInputElement;
+}
+
 describe('PlayerListField - 생년월일 입력', () => {
   it('달력 위젯 대신 숫자 키패드를 띄우는 텍스트 입력으로 렌더링한다', () => {
     renderPlayerListField();
@@ -105,6 +112,67 @@ describe('PlayerListField - 생년월일 입력', () => {
   });
 });
 
+describe('PlayerListField - 전화번호 입력', () => {
+  it('숫자 키패드를 띄우고 하이픈 포함 길이로 제한한다', () => {
+    renderPlayerListField();
+    const input = getPhoneNumberInput();
+
+    expect(input.getAttribute('inputmode')).toBe('numeric');
+    expect(input.getAttribute('maxlength')).toBe('13');
+  });
+
+  it('숫자만 입력해도 하이픈을 붙여 보여준다', () => {
+    renderPlayerListField();
+    const input = getPhoneNumberInput();
+
+    fireEvent.change(input, { target: { value: '01012345678' } });
+
+    expect(input.value).toBe('010-1234-5678');
+  });
+
+  it('입력 중에도 자리 수에 맞춰 하이픈을 붙인다', () => {
+    renderPlayerListField();
+    const input = getPhoneNumberInput();
+
+    fireEvent.change(input, { target: { value: '0101' } });
+
+    expect(input.value).toBe('010-1');
+  });
+
+  it('11자리를 넘겨 입력해도 잘라낸다', () => {
+    renderPlayerListField();
+    const input = getPhoneNumberInput();
+
+    fireEvent.change(input, { target: { value: '010123456789999' } });
+
+    expect(input.value).toBe('010-1234-5678');
+  });
+
+  it('자동 채움된 하이픈 값을 그대로 표시한다', () => {
+    renderPlayerListField({ players: [{ phoneNumber: '010-1111-2222' }] });
+
+    expect(getPhoneNumberInput().value).toBe('010-1111-2222');
+  });
+
+  it('저장 값은 숫자만 남긴 형태로 제출한다', async () => {
+    const onSubmit = jest.fn();
+    renderPlayerListField({
+      players: [{ name: '홍길동', gender: '남', birthDate: '1990-03-15' }],
+      onSubmit,
+    });
+
+    fireEvent.change(getPhoneNumberInput(), {
+      target: { value: '010-1234-5678' },
+    });
+    fireEvent.click(screen.getByText('제출'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+
+    const submitted = onSubmit.mock.calls[0][0] as EntryFormValues;
+    expect(submitted.players[0].phoneNumber).toBe('01012345678');
+  });
+});
+
 describe('PlayerListField - 검증 메시지', () => {
   let onSubmit: jest.Mock;
 
@@ -143,6 +211,32 @@ describe('PlayerListField - 검증 메시지', () => {
     fireEvent.click(screen.getByText('제출'));
 
     expect(await screen.findByText('올바른 생년월일이 아닙니다.')).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('자릿수가 모자란 전화번호를 거부한다', async () => {
+    renderPlayerListField({ onSubmit });
+
+    fireEvent.change(getPhoneNumberInput(), { target: { value: '010-1234' } });
+    fireEvent.click(screen.getByText('제출'));
+
+    expect(
+      await screen.findByText('올바른 전화번호가 아닙니다. (예: 010-1234-5678)')
+    ).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('휴대폰 국번이 아닌 번호를 거부한다', async () => {
+    renderPlayerListField({ onSubmit });
+
+    fireEvent.change(getPhoneNumberInput(), {
+      target: { value: '02-1234-5678' },
+    });
+    fireEvent.click(screen.getByText('제출'));
+
+    expect(
+      await screen.findByText('올바른 전화번호가 아닙니다. (예: 010-1234-5678)')
+    ).toBeTruthy();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/src/components/organisms/tournament/entry/PlayerListField.tsx
+++ b/src/components/organisms/tournament/entry/PlayerListField.tsx
@@ -9,6 +9,11 @@ import {
   toBirthDateDigits,
   toIsoBirthDate,
 } from '@/utils/birthDate';
+import {
+  formatPhoneNumber,
+  getPhoneNumberError,
+  toPhoneDigits,
+} from '@/utils/phoneNumber';
 
 import {
   createEmptyPlayer,
@@ -166,12 +171,27 @@ function PlayerListField({ tshirtSizes }: PlayerListFieldProps) {
                 required
                 error={playerErrors?.phoneNumber?.message}
               >
-                <Input
-                  type="tel"
-                  placeholder="010-1234-5678"
-                  {...register(`players.${index}.phoneNumber`, {
-                    required: '전화번호를 입력해주세요.',
-                  })}
+                <Controller
+                  control={control}
+                  name={`players.${index}.phoneNumber`}
+                  rules={{ validate: getPhoneNumberError }}
+                  render={({ field }) => (
+                    <Input
+                      type="tel"
+                      inputMode="numeric"
+                      autoComplete="tel"
+                      // '010-1234-5678' = 13자. 하이픈은 자동으로 붙는다.
+                      maxLength={13}
+                      placeholder="010-1234-5678"
+                      // 숫자만 입력해도 하이픈이 붙은 형태로 보여준다.
+                      value={formatPhoneNumber(field.value)}
+                      onChange={(event) =>
+                        field.onChange(toPhoneDigits(event.target.value))
+                      }
+                      onBlur={field.onBlur}
+                      ref={field.ref}
+                    />
+                  )}
                 />
               </FormField>
 

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { isValidBirthDate, toIsoBirthDate } from '@/utils/birthDate';
+import { formatPhoneNumber, isValidPhoneNumber } from '@/utils/phoneNumber';
 
 const eventTypeSchema = z.object({
   // 폼의 hidden input이 신규 종목에 빈 문자열을 넣으므로 undefined로 정규화한다.
@@ -72,7 +73,14 @@ const playerSchema = z.object({
     .min(1, '생년월일을 입력해주세요.')
     .transform(toIsoBirthDate)
     .refine(isValidBirthDate, '올바른 생년월일이 아닙니다.'),
-  phoneNumber: z.string().trim().min(1, '전화번호를 입력해주세요.'),
+  // 클라이언트가 숫자만 보내든 하이픈을 섞어 보내든 저장 포맷을 하나로 맞춘다.
+  // 형식까지 확인해야 문자 발송(src/lib/sms.ts) 단계에서 뒤늦게 실패하지 않는다.
+  phoneNumber: z
+    .string()
+    .trim()
+    .min(1, '전화번호를 입력해주세요.')
+    .refine(isValidPhoneNumber, '올바른 전화번호가 아닙니다.')
+    .transform(formatPhoneNumber),
   tshirtSize: z.string().trim().nullable().optional(),
   order: z.number().int().min(0).default(0),
 });

--- a/src/utils/__tests__/phoneNumber.test.ts
+++ b/src/utils/__tests__/phoneNumber.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  formatPhoneNumber,
+  getPhoneNumberError,
+  isValidPhoneNumber,
+  toPhoneDigits,
+} from '@/utils/phoneNumber';
+
+describe('toPhoneDigits', () => {
+  it('하이픈이 섞인 입력에서 숫자만 남긴다', () => {
+    expect(toPhoneDigits('010-1234-5678')).toBe('01012345678');
+  });
+
+  it('공백과 괄호도 걷어낸다', () => {
+    expect(toPhoneDigits('(010) 1234 5678')).toBe('01012345678');
+  });
+
+  it('빈 값과 null을 빈 문자열로 처리한다', () => {
+    expect(toPhoneDigits('')).toBe('');
+    expect(toPhoneDigits(null)).toBe('');
+    expect(toPhoneDigits(undefined)).toBe('');
+  });
+
+  it('11자리를 넘는 입력은 잘라낸다', () => {
+    expect(toPhoneDigits('010123456789999')).toBe('01012345678');
+  });
+});
+
+describe('formatPhoneNumber', () => {
+  it('11자리를 3-4-4로 끊는다', () => {
+    expect(formatPhoneNumber('01012345678')).toBe('010-1234-5678');
+  });
+
+  it('10자리를 3-3-4로 끊는다', () => {
+    expect(formatPhoneNumber('0111234567')).toBe('011-123-4567');
+  });
+
+  it('이미 하이픈이 붙은 값을 그대로 유지한다', () => {
+    expect(formatPhoneNumber('010-1234-5678')).toBe('010-1234-5678');
+  });
+
+  it('입력 중인 값도 자리 수에 맞춰 끊는다', () => {
+    expect(formatPhoneNumber('010')).toBe('010');
+    expect(formatPhoneNumber('0101')).toBe('010-1');
+    expect(formatPhoneNumber('0101234')).toBe('010-1234');
+  });
+
+  it('빈 값을 빈 문자열로 처리한다', () => {
+    expect(formatPhoneNumber('')).toBe('');
+    expect(formatPhoneNumber(null)).toBe('');
+  });
+});
+
+describe('isValidPhoneNumber', () => {
+  it('휴대폰 번호를 통과시킨다', () => {
+    expect(isValidPhoneNumber('010-1234-5678')).toBe(true);
+    expect(isValidPhoneNumber('01012345678')).toBe(true);
+    expect(isValidPhoneNumber('011-123-4567')).toBe(true);
+  });
+
+  it('자리 수가 모자라면 거절한다', () => {
+    // 국번을 뺀 뒷자리가 7자리는 되어야 한다.
+    expect(isValidPhoneNumber('010-123-456')).toBe(false);
+    expect(isValidPhoneNumber('0101')).toBe(false);
+  });
+
+  it('휴대폰 국번이 아니면 거절한다', () => {
+    expect(isValidPhoneNumber('02-1234-5678')).toBe(false);
+    expect(isValidPhoneNumber('070-1234-5678')).toBe(false);
+  });
+
+  it('빈 값을 거절한다', () => {
+    expect(isValidPhoneNumber('')).toBe(false);
+    expect(isValidPhoneNumber(null)).toBe(false);
+  });
+});
+
+describe('getPhoneNumberError', () => {
+  it('빈 값에 입력 안내를 돌려준다', () => {
+    expect(getPhoneNumberError('')).toBe('전화번호를 입력해주세요.');
+  });
+
+  it('형식이 어긋나면 예시를 담은 안내를 돌려준다', () => {
+    expect(getPhoneNumberError('010-1234')).toBe(
+      '올바른 전화번호가 아닙니다. (예: 010-1234-5678)'
+    );
+  });
+
+  it('유효한 번호에는 undefined를 돌려준다', () => {
+    expect(getPhoneNumberError('010-1234-5678')).toBeUndefined();
+    expect(getPhoneNumberError('01012345678')).toBeUndefined();
+  });
+});

--- a/src/utils/phoneNumber.ts
+++ b/src/utils/phoneNumber.ts
@@ -1,0 +1,63 @@
+/**
+ * 휴대폰 번호로 인정하는 형식.
+ * 010~019로 시작하고 뒤에 7~8자리가 붙는다.
+ * 문자 발송(src/lib/sms.ts)이 쓰는 규칙과 같은 형식이어야
+ * 폼을 통과한 번호가 발송 단계에서 뒤늦게 거절되지 않는다.
+ */
+const PHONE_NUMBER_PATTERN = /^01[0-9]\d{7,8}$/;
+
+/** 하이픈까지 포함한 최대 길이('010-1234-5678' = 11자리). */
+const MAX_PHONE_DIGITS = 11;
+
+/**
+ * 전화번호 입력을 숫자만 남기는 함수
+ * 사용자가 하이픈이나 공백을 섞어 넣어도 동일한 형태로 맞춘다.
+ * @param value - 사용자 입력 또는 저장된 전화번호 문자열
+ * @returns 숫자만 남긴 최대 11자리 문자열
+ */
+export const toPhoneDigits = (value?: string | null): string => {
+  if (!value) return '';
+  return value.replace(/\D/g, '').slice(0, MAX_PHONE_DIGITS);
+};
+
+/**
+ * 숫자만 있는 전화번호를 하이픈 포맷으로 바꾸는 함수
+ * 입력 중에도 자연스럽게 보이도록 자리 수에 맞춰 점진적으로 끊는다.
+ * @param value - '01012345678' 형태의 문자열 (하이픈이 섞여 있어도 된다)
+ * @returns '010-1234-5678' 형태의 문자열
+ */
+export const formatPhoneNumber = (value?: string | null): string => {
+  const digits = toPhoneDigits(value);
+  if (digits.length < 4) return digits;
+  if (digits.length < 8) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+
+  // 10자리(예: 011-123-4567)는 가운데가 3자리, 11자리는 4자리다.
+  const middleLength = digits.length === 10 ? 3 : 4;
+  return `${digits.slice(0, 3)}-${digits.slice(3, 3 + middleLength)}-${digits.slice(3 + middleLength)}`;
+};
+
+/**
+ * 전화번호가 유효한지 검사하는 함수
+ * @param value - 하이픈이 있든 없든 상관없는 전화번호 문자열
+ * @returns 유효하면 true
+ */
+export const isValidPhoneNumber = (value?: string | null): boolean =>
+  PHONE_NUMBER_PATTERN.test(toPhoneDigits(value));
+
+/**
+ * 전화번호 입력값에 대한 오류 메시지를 돌려주는 함수
+ * 폼에서 react-hook-form의 validate에 그대로 연결해 쓴다.
+ * @param value - 사용자가 입력한 문자열
+ * @returns 오류 메시지. 유효하면 undefined
+ */
+export const getPhoneNumberError = (
+  value?: string | null
+): string | undefined => {
+  const digits = toPhoneDigits(value);
+
+  if (digits.length === 0) return '전화번호를 입력해주세요.';
+  if (!isValidPhoneNumber(digits))
+    return '올바른 전화번호가 아닙니다. (예: 010-1234-5678)';
+
+  return undefined;
+};


### PR DESCRIPTION
## 문제

대회 신청 폼의 전화번호 필드에 `required` 외 검증이 없어, 플레이스홀더(`010-1234-5678`)와 무관한 아무 문자열이나 길이 제한 없이 통과했습니다.

부수적으로, 폼을 통과한 값이 문자 발송 단계(`src/lib/sms.ts`)에서 뒤늦게 거절되는 틈도 있었습니다.

## 변경 내용

| 파일 | 내용 |
|---|---|
| `src/utils/phoneNumber.ts` (신규) | 정규화·포맷·검증 유틸 |
| `PlayerListField.tsx` | `register` → `Controller`로 교체, 자동 하이픈 + 검증 연결 |
| `src/schemas/tournament.schema.ts` | 서버 측 형식 검증 + 저장 포맷 정규화 |
| `phoneNumber.test.ts` (신규) | 유틸 단위 테스트 |
| `PlayerListField.dom.test.tsx` | 입력/검증 DOM 테스트 추가 |

## 동작

- **자동 하이픈**: `01012345678` 입력 → `010-1234-5678` 표시. 입력 중에도 자리 수에 맞춰 끊깁니다 (10자리는 `011-123-4567`).
- **길이 제한**: 숫자 11자리 초과분은 잘라냅니다 (`maxLength={13}`은 하이픈 포함).
- **형식 검증**: `/^01[0-9]\d{7,8}$/` — 이미 `sms.ts:59`가 쓰던 규칙과 같은 형식으로 맞춰, 발송 단계에서 뒤늦게 실패하던 틈을 막았습니다.
- **오류 메시지**: 빈 값은 `전화번호를 입력해주세요.`, 형식 오류는 `올바른 전화번호가 아닙니다. (예: 010-1234-5678)`.

기존 `birthDate` 필드가 세운 패턴(유틸 분리 + `Controller` + 스키마 `transform`)을 그대로 따랐습니다.

## 리뷰 포인트

폼의 **저장 값은 숫자만**(`01012345678`), **서버 스키마는 하이픈 포맷**(`010-1234-5678`)으로 정규화합니다. 기존 DB 값이 하이픈 형태였기에 저장 포맷을 거기에 맞췄습니다. 숫자만 저장하는 쪽을 선호하면 `tournament.schema.ts`의 `.transform(formatPhoneNumber)`를 `.transform(toPhoneDigits)`로 바꾸면 됩니다.

## 검증

- 변경 파일 lint 통과, 신규/수정 테스트 46건 전부 통과.
- `sms-notification.test.ts` / `GuestPageStrategy.test.ts` 실패와 tsc 오류 13건은 **이 변경 전에도 동일하게 실패**하던 기존 이슈입니다 (`git stash` 대조 확인). 손대지 않았습니다.

## 참고

DOM 테스트 실행에 필요한 `jest-environment-jsdom` 의존성 추가는 이 브랜치에 포함되지 않았습니다(부모 브랜치의 미커밋 변경). 단독 CI 실행 시 DOM 테스트가 깨질 수 있습니다.