### PR TITLE
feat(tournament): 종목 단위 현황을 팀 단위로 묶어 표시

### DIFF
--- a/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
+++ b/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import EventGroupList from '@/components/organisms/tournament/admin/EventGroupList';
+
+import type { EventGroup } from '@/lib/tournament/groupEntriesByEvent';
+
+const 남자복식: EventGroup = {
+  label: '남자복식 30대 A조',
+  playerCount: 4,
+  teams: [
+    {
+      entryId: 'e1',
+      depositorName: '김철수',
+      teamName: '무적클럽',
+      paymentStatus: 'CONFIRMED',
+      players: [
+        {
+          name: '김철수',
+          birthDate: '1990-03-15',
+          phoneNumber: '010-1111-1111',
+          tshirtSize: 'L',
+        },
+        {
+          name: '박영희',
+          birthDate: '1992-07-01',
+          phoneNumber: '010-2222-2222',
+          tshirtSize: null,
+        },
+      ],
+    },
+    {
+      entryId: 'e2',
+      depositorName: '이민수',
+      teamName: null,
+      paymentStatus: 'PENDING',
+      players: [
+        {
+          name: '이민수',
+          birthDate: '1988-05-05',
+          phoneNumber: '010-3333-3333',
+          tshirtSize: 'M',
+        },
+        {
+          name: '정다은',
+          birthDate: '1995-12-25',
+          phoneNumber: '010-4444-4444',
+          tshirtSize: 'S',
+        },
+      ],
+    },
+  ],
+};
+
+describe('EventGroupList', () => {
+  it('종목 제목에 팀 수와 인원 수를 함께 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    expect(screen.getByText('남자복식 30대 A조')).toBeTruthy();
+    expect(screen.getByText('2팀 / 4명')).toBeTruthy();
+  });
+
+  it('파트너 이름을 한 줄에 묶어 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    // 평평한 목록이었다면 이름이 각각 흩어져 팀을 알 수 없었다.
+    expect(screen.getByText('김철수 · 박영희')).toBeTruthy();
+    expect(screen.getByText('이민수 · 정다은')).toBeTruthy();
+  });
+
+  it('팀마다 신청서의 입금 상태를 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    expect(screen.getByText('입금확인')).toBeTruthy();
+    expect(screen.getByText('입금대기')).toBeTruthy();
+  });
+
+  it('선수별 생년월일·연락처·티셔츠를 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    // 연령부 자격 확인에 생년월일이 필요하다.
+    expect(screen.getByText('1990-03-15')).toBeTruthy();
+    expect(screen.getByText('1992-07-01')).toBeTruthy();
+    expect(screen.getByText('010-1111-1111')).toBeTruthy();
+    expect(screen.getByText('티셔츠 L')).toBeTruthy();
+    // 티셔츠를 안 쓰는 대회는 값이 없으므로 '-'로 채운다.
+    expect(screen.getByText('티셔츠 -')).toBeTruthy();
+  });
+
+  it('useTeamName이 켜져 있으면 팀명을 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName />);
+
+    expect(screen.getByText('(무적클럽)')).toBeTruthy();
+  });
+
+  it('useTeamName이 꺼져 있으면 팀명을 숨긴다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    expect(screen.queryByText('(무적클럽)')).toBeNull();
+  });
+
+  it('단식은 이름 하나만 보여준다', () => {
+    const 단식: EventGroup = {
+      label: '남자단식 30대 A조',
+      playerCount: 1,
+      teams: [
+        {
+          entryId: 'e1',
+          depositorName: '김철수',
+          teamName: null,
+          paymentStatus: 'PENDING',
+          players: [
+            {
+              name: '김철수',
+              birthDate: '1990-03-15',
+              phoneNumber: '010-1111-1111',
+              tshirtSize: 'L',
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<EventGroupList groups={[단식]} useTeamName={false} />);
+
+    // 팀 이름 줄과 선수 상세 줄에 각각 한 번씩 나온다. 가운뎃점은 없어야 한다.
+    expect(screen.getAllByText('김철수')).toHaveLength(2);
+    expect(screen.queryByText(/·/)).toBeNull();
+    expect(screen.getByText('1팀 / 1명')).toBeTruthy();
+  });
+
+  it('묶음이 없으면 안내 문구를 보여준다', () => {
+    render(<EventGroupList groups={[]} useTeamName={false} />);
+
+    expect(screen.getByText('신청 내역이 없습니다.')).toBeTruthy();
+  });
+});

--- a/src/components/organisms/tournament/admin/EventGroupList.tsx
+++ b/src/components/organisms/tournament/admin/EventGroupList.tsx
@@ -1,0 +1,92 @@
+import { PAYMENT_CLASS, PAYMENT_LABEL } from '@/lib/tournament/display';
+import type {
+  EventGroup,
+  GroupedTeam,
+} from '@/lib/tournament/groupEntriesByEvent';
+
+interface EventGroupListProps {
+  groups: EventGroup[];
+  useTeamName: boolean;
+}
+
+/** 팀을 이룬 선수를 '이름 · 이름' 형태로 잇는다. 단식이면 이름 하나만 남는다. */
+function TeamPlayerNames({ team }: { team: GroupedTeam }) {
+  return (
+    <span className="font-medium">
+      {team.players.map((player) => player.name).join(' · ')}
+    </span>
+  );
+}
+
+function EventGroupList({ groups, useTeamName }: EventGroupListProps) {
+  if (groups.length === 0) {
+    return (
+      <p className="rounded-md bg-gray-50 p-6 text-center text-sm text-gray-500">
+        신청 내역이 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {groups.map((group) => (
+        <section
+          key={group.label}
+          className="rounded-lg border border-gray-200 p-4"
+        >
+          <h3 className="mb-3 font-medium">
+            {group.label}{' '}
+            <span className="text-sm text-gray-400">
+              {group.teams.length}팀 / {group.playerCount}명
+            </span>
+          </h3>
+
+          <ul className="space-y-2">
+            {group.teams.map((team, index) => (
+              <li
+                key={`${team.entryId}-${index}`}
+                className="rounded-md bg-gray-50 p-3"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-1">
+                  <div className="flex items-baseline gap-2">
+                    {/* 팀 번호가 있어야 인원이 많은 종목에서 줄을 세어 읽기 쉽다. */}
+                    <span className="text-xs text-gray-400">{index + 1}</span>
+                    <TeamPlayerNames team={team} />
+                    {useTeamName && team.teamName && (
+                      <span className="text-xs text-gray-500">
+                        ({team.teamName})
+                      </span>
+                    )}
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-full px-2 py-0.5 text-xs ${PAYMENT_CLASS[team.paymentStatus]}`}
+                  >
+                    {PAYMENT_LABEL[team.paymentStatus]}
+                  </span>
+                </div>
+
+                {/* 연락처·티셔츠는 한 단계 낮춰 팀 경계가 먼저 읽히게 한다. */}
+                <ul className="mt-1 space-y-0.5 pl-5">
+                  {team.players.map((player, playerIndex) => (
+                    <li
+                      key={`${player.name}-${playerIndex}`}
+                      className="flex flex-wrap items-baseline gap-x-2 text-xs text-gray-500"
+                    >
+                      <span>{player.name}</span>
+                      {/* 연령부 자격을 확인하려면 관리자에게 생년월일이 필요하다. */}
+                      <span>{player.birthDate || '-'}</span>
+                      <span>{player.phoneNumber}</span>
+                      <span>티셔츠 {player.tshirtSize ?? '-'}</span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export default EventGroupList;

--- a/src/lib/tournament/groupEntriesByEvent.test.ts
+++ b/src/lib/tournament/groupEntriesByEvent.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { EntryPaymentStatus } from '@/types/tournament.types';
+
+import { groupEntriesByEvent } from './groupEntriesByEvent';
+
+/** 테스트마다 필요한 부분만 덮어쓰도록 최소 신청서를 만든다. */
+function createEntry(options: {
+  id: string;
+  depositorName?: string;
+  teamName?: string | null;
+  paymentStatus?: EntryPaymentStatus;
+  events: Array<{
+    eventType?: string;
+    ageGroup?: string;
+    level?: string;
+    status?: string;
+    players: string[];
+  }>;
+}) {
+  return {
+    id: options.id,
+    depositorName: options.depositorName ?? '입금자',
+    teamName: options.teamName ?? null,
+    paymentStatus: options.paymentStatus ?? ('PENDING' as EntryPaymentStatus),
+    entryEvents: options.events.map((event) => ({
+      status: event.status ?? 'ACTIVE',
+      ageGroup: event.ageGroup ?? '30대',
+      level: event.level ?? 'A조',
+      eventType: { name: event.eventType ?? '남자복식' },
+      eventPlayers: event.players.map((name) => ({
+        entryPlayer: {
+          name,
+          birthDate: '1990-03-15',
+          phoneNumber: `010-0000-000${name.length}`,
+          tshirtSize: null,
+        },
+      })),
+    })),
+  };
+}
+
+describe('groupEntriesByEvent', () => {
+  it('같은 종목의 신청을 하나로 묶는다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수', '박영희'] }] }),
+      createEntry({ id: 'e2', events: [{ players: ['이민수', '정다은'] }] }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('남자복식 30대 A조');
+    expect(result[0].teams).toHaveLength(2);
+  });
+
+  it('복식 파트너를 한 팀으로 유지한다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수', '박영희'] }] }),
+      createEntry({ id: 'e2', events: [{ players: ['이민수', '정다은'] }] }),
+    ]);
+
+    // 평평하게 폈다면 4명이 한 줄로 늘어서 팀 경계를 알 수 없다.
+    expect(result[0].teams[0].players.map((p) => p.name)).toEqual([
+      '김철수',
+      '박영희',
+    ]);
+    expect(result[0].teams[1].players.map((p) => p.name)).toEqual([
+      '이민수',
+      '정다은',
+    ]);
+  });
+
+  it('종목이 다르면 서로 다른 묶음으로 나눈다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [
+          { players: ['김철수', '박영희'] },
+          { eventType: '혼합복식', players: ['김철수', '정다은'] },
+        ],
+      }),
+    ]);
+
+    expect(result.map((group) => group.label)).toEqual([
+      '남자복식 30대 A조',
+      '혼합복식 30대 A조',
+    ]);
+  });
+
+  it('같은 종목이라도 연령·급수가 다르면 나눈다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수', '박영희'] }] }),
+      createEntry({
+        id: 'e2',
+        events: [{ ageGroup: '40대', players: ['이민수', '정다은'] }],
+      }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('취소된 종목은 제외한다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [{ status: 'CANCELED', players: ['김철수', '박영희'] }],
+      }),
+    ]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('한 신청서가 같은 종목에 여러 팀을 내면 각각 별도 팀으로 쌓는다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [
+          { players: ['김철수', '박영희'] },
+          { players: ['이민수', '정다은'] },
+        ],
+      }),
+    ]);
+
+    expect(result[0].teams).toHaveLength(2);
+    expect(result[0].teams.every((team) => team.entryId === 'e1')).toBe(true);
+  });
+
+  it('단식은 한 팀에 한 명으로 묶는다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [{ eventType: '남자단식', players: ['김철수'] }],
+      }),
+    ]);
+
+    expect(result[0].teams[0].players).toHaveLength(1);
+  });
+
+  it('종목별 총 인원을 센다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수', '박영희'] }] }),
+      createEntry({ id: 'e2', events: [{ players: ['이민수', '정다은'] }] }),
+      createEntry({ id: 'e3', events: [{ players: ['홍길동', '손흥민'] }] }),
+    ]);
+
+    expect(result[0].teams).toHaveLength(3);
+    expect(result[0].playerCount).toBe(6);
+  });
+
+  it('팀에 신청서의 입금 상태와 입금자명을 남긴다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        depositorName: '김철수',
+        paymentStatus: 'CONFIRMED',
+        events: [{ players: ['김철수', '박영희'] }],
+      }),
+    ]);
+
+    expect(result[0].teams[0].paymentStatus).toBe('CONFIRMED');
+    expect(result[0].teams[0].depositorName).toBe('김철수');
+  });
+
+  it('종목이 처음 등장한 순서를 유지한다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [
+          { eventType: '혼합복식', players: ['김철수', '정다은'] },
+          { eventType: '남자복식', players: ['김철수', '박영희'] },
+        ],
+      }),
+    ]);
+
+    expect(result.map((group) => group.label)).toEqual([
+      '혼합복식 30대 A조',
+      '남자복식 30대 A조',
+    ]);
+  });
+
+  it('선수의 생년월일을 함께 넘긴다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수'] }] }),
+    ]);
+
+    expect(result[0].teams[0].players[0].birthDate).toBe('1990-03-15');
+  });
+
+  it('빈 목록이면 빈 배열을 반환한다', () => {
+    expect(groupEntriesByEvent([])).toEqual([]);
+  });
+});

--- a/src/lib/tournament/groupEntriesByEvent.ts
+++ b/src/lib/tournament/groupEntriesByEvent.ts
@@ -1,0 +1,102 @@
+import type { EntryPaymentStatus } from '@/types/tournament.types';
+
+import { formatEventLabel } from './display';
+
+/** 종목 묶음 안에서 한 팀을 이루는 선수 한 명. */
+export interface GroupedPlayer {
+  name: string;
+  birthDate: string;
+  phoneNumber: string;
+  tshirtSize: string | null;
+}
+
+/**
+ * 한 신청서가 한 종목에 낸 팀 하나.
+ * 복식이면 players가 2명, 단식이면 1명이다.
+ */
+export interface GroupedTeam {
+  entryId: string;
+  depositorName: string;
+  teamName: string | null;
+  paymentStatus: EntryPaymentStatus;
+  players: GroupedPlayer[];
+}
+
+/** 종목 하나에 모인 팀 목록. */
+export interface EventGroup {
+  label: string;
+  teams: GroupedTeam[];
+  playerCount: number;
+}
+
+/** 그룹핑에 필요한 최소 형태만 받는다. Prisma 전체 타입에 묶이지 않게 한다. */
+interface GroupableEntry {
+  id: string;
+  depositorName: string;
+  teamName: string | null;
+  paymentStatus: EntryPaymentStatus;
+  entryEvents: Array<{
+    status: string;
+    ageGroup: string;
+    level: string;
+    eventType: { name: string };
+    eventPlayers: Array<{
+      entryPlayer: {
+        name: string;
+        birthDate: string;
+        phoneNumber: string;
+        tshirtSize: string | null;
+      };
+    }>;
+  }>;
+}
+
+/**
+ * 신청 목록을 종목별로 묶고, 종목 안에서는 다시 팀 단위로 묶는 함수
+ *
+ * 선수를 평평하게 늘어놓으면 복식에서 누가 누구와 한 팀인지 알 수 없다.
+ * 신청서 하나가 한 종목에 낸 eventPlayers가 곧 한 팀이므로, 그 경계를
+ * 유지한 채로 쌓는다.
+ *
+ * 취소(CANCELED)된 종목은 제외한다. 신청서 자체의 입금 상태는 팀에 남겨
+ * 화면에서 배지로 보여준다.
+ *
+ * @param entries - 관리자용 신청 목록
+ * @returns 종목별 묶음 배열. 종목이 처음 등장한 순서를 유지한다.
+ */
+export function groupEntriesByEvent(entries: GroupableEntry[]): EventGroup[] {
+  const groups = new Map<string, GroupedTeam[]>();
+
+  for (const entry of entries) {
+    for (const event of entry.entryEvents) {
+      if (event.status !== 'ACTIVE') continue;
+
+      const label = formatEventLabel({
+        eventType: event.eventType.name,
+        ageGroup: event.ageGroup,
+        level: event.level,
+      });
+
+      const teams = groups.get(label) ?? [];
+      teams.push({
+        entryId: entry.id,
+        depositorName: entry.depositorName,
+        teamName: entry.teamName,
+        paymentStatus: entry.paymentStatus,
+        players: event.eventPlayers.map((eventPlayer) => ({
+          name: eventPlayer.entryPlayer.name,
+          birthDate: eventPlayer.entryPlayer.birthDate,
+          phoneNumber: eventPlayer.entryPlayer.phoneNumber,
+          tshirtSize: eventPlayer.entryPlayer.tshirtSize,
+        })),
+      });
+      groups.set(label, teams);
+    }
+  }
+
+  return Array.from(groups.entries()).map(([label, teams]) => ({
+    label,
+    teams,
+    playerCount: teams.reduce((sum, team) => sum + team.players.length, 0),
+  }));
+}

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/admin.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/admin.tsx
@@ -6,6 +6,7 @@ import toast from 'react-hot-toast';
 
 import DeleteTournamentDialog from '@/components/organisms/tournament/admin/DeleteTournamentDialog';
 import EntryTable from '@/components/organisms/tournament/admin/EntryTable';
+import EventGroupList from '@/components/organisms/tournament/admin/EventGroupList';
 
 import {
   useAdminEntries,
@@ -14,7 +15,8 @@ import {
 } from '@/hooks/useTournamentAdmin';
 import { useTournamentDetail } from '@/hooks/useTournamentDetail';
 
-import { formatEventLabel, formatFee } from '@/lib/tournament/display';
+import { formatFee } from '@/lib/tournament/display';
+import { groupEntriesByEvent } from '@/lib/tournament/groupEntriesByEvent';
 import type { EntryPaymentStatus } from '@/types/tournament.types';
 
 type ViewMode = 'entry' | 'event';
@@ -43,34 +45,8 @@ function TournamentAdminPage() {
     [entries, statusFilter]
   );
 
-  // 종목별 신청 인원 집계
-  const eventGroups = useMemo(() => {
-    const groups = new Map<
-      string,
-      Array<{ name: string; phoneNumber: string; tshirtSize: string | null }>
-    >();
-
-    for (const entry of filtered) {
-      for (const event of entry.entryEvents) {
-        if (event.status !== 'ACTIVE') continue;
-        const label = formatEventLabel({
-          eventType: event.eventType.name,
-          ageGroup: event.ageGroup,
-          level: event.level,
-        });
-        const list = groups.get(label) ?? [];
-        for (const eventPlayer of event.eventPlayers) {
-          list.push({
-            name: eventPlayer.entryPlayer.name,
-            phoneNumber: eventPlayer.entryPlayer.phoneNumber,
-            tshirtSize: eventPlayer.entryPlayer.tshirtSize,
-          });
-        }
-        groups.set(label, list);
-      }
-    }
-    return Array.from(groups.entries());
-  }, [filtered]);
+  // 종목별로 묶고, 종목 안에서는 다시 팀(파트너) 단위로 묶는다.
+  const eventGroups = useMemo(() => groupEntriesByEvent(filtered), [filtered]);
 
   const totalConfirmed = useMemo(
     () =>
@@ -217,70 +193,10 @@ function TournamentAdminPage() {
           onChangePaymentStatus={onChangePaymentStatus}
         />
       ) : (
-        <div className="space-y-4">
-          {eventGroups.map(([label, players]) => (
-            <section
-              key={label}
-              className="rounded-lg border border-gray-200 p-4"
-            >
-              <h3 className="mb-2 font-medium">
-                {label}{' '}
-                <span className="text-sm text-gray-400">
-                  {players.length}명
-                </span>
-              </h3>
-              {/* 모바일: 카드 목록 */}
-              <ul className="space-y-2 text-sm sm:hidden">
-                {players.map((player, index) => (
-                  <li
-                    key={`${player.name}-${index}`}
-                    className="rounded-md bg-gray-50 p-2"
-                  >
-                    <div className="flex items-baseline justify-between gap-2">
-                      <span className="font-medium">{player.name}</span>
-                      <span className="shrink-0 text-xs text-gray-500">
-                        티셔츠 {player.tshirtSize ?? '-'}
-                      </span>
-                    </div>
-                    <p className="mt-0.5 text-xs text-gray-500">
-                      {player.phoneNumber}
-                    </p>
-                  </li>
-                ))}
-              </ul>
-
-              {/* PC: 표 */}
-              <div className="hidden overflow-x-auto sm:block">
-                <table className="w-full min-w-[360px] text-sm">
-                  <thead>
-                    <tr className="border-b text-left text-gray-500">
-                      <th className="py-1">이름</th>
-                      <th className="py-1">연락처</th>
-                      <th className="py-1">티셔츠</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {players.map((player, index) => (
-                      <tr
-                        key={`${player.name}-${index}`}
-                        className="border-b last:border-0"
-                      >
-                        <td className="py-1">{player.name}</td>
-                        <td className="py-1">{player.phoneNumber}</td>
-                        <td className="py-1">{player.tshirtSize ?? '-'}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          ))}
-          {eventGroups.length === 0 && (
-            <p className="rounded-md bg-gray-50 p-6 text-center text-sm text-gray-500">
-              신청 내역이 없습니다.
-            </p>
-          )}
-        </div>
+        <EventGroupList
+          groups={eventGroups}
+          useTeamName={detail?.tournament.useTeamName ?? false}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## 문제

관리자 신청 현황(`admin.tsx`)의 **종목 단위 뷰**가 종목 안의 모든 선수를 평평한 한 줄로 펼쳤습니다. 그래서 복식에서 **누가 누구와 한 팀인지 알 수 없었습니다** — 3팀이 신청하면 6명이 그냥 일렬로 늘어섰습니다.

## 해결

신청서 하나가 한 종목에 낸 `eventPlayers`가 곧 한 팀이므로, 그 경계를 유지한 채 쌓도록 바꿨습니다. 기존 데이터 구조만으로 가능해 **API 변경은 없습니다**.

### Before

```
남자복식 30대 A조   4명
─────────────────────────
이름     연락처            티셔츠
김철수   010-1111-1111    L
박영희   010-2222-2222    -
이민수   010-3333-3333    M
정다은   010-4444-4444    S
```

### After

```
남자복식 30대 A조   2팀 / 4명
─────────────────────────────
1  김철수 · 박영희  (무적클럽)   [입금확인]
     김철수  1990-03-15  010-1111-1111  티셔츠 L
     박영희  1992-07-01  010-2222-2222  티셔츠 -

2  이민수 · 정다은              [입금대기]
     이민수  1988-05-05  010-3333-3333  티셔츠 M
     정다은  1995-12-25  010-4444-4444  티셔츠 S
```

## 변경 내용

| 파일 | 내용 |
|---|---|
| `src/lib/tournament/groupEntriesByEvent.ts` (신규) | 종목별 → 팀별 2단 그룹핑 순수 로직 |
| `EventGroupList.tsx` (신규) | 종목 단위 뷰 표시 컴포넌트 |
| `admin.tsx` | 인라인 집계 27줄 → 함수 호출 1줄, JSX 60여 줄 → 컴포넌트로 분리 |
| `groupEntriesByEvent.test.ts` (신규) | 그룹핑 단위 테스트 12건 |
| `EventGroupList.dom.test.tsx` (신규) | 렌더링 DOM 테스트 8건 |

부수적으로 개선한 점:

- **입금 상태 배지**를 팀마다 붙여, 종목 화면에서 미입금을 바로 확인할 수 있습니다 (기존엔 신청서 뷰로 넘어가야 했습니다).
- **생년월일**을 선수 줄에 추가했습니다. 연령부 자격 확인에 필요한 값입니다.
- 헤더 집계를 `4명` → `2팀 / 4명`으로 바꿔 팀 수를 바로 셀 수 있습니다.
- 팀명은 대회의 `useTeamName`이 켜진 경우에만 표시합니다.
- 단식은 자연히 한 팀 = 한 명으로 떨어집니다.

## 리뷰 포인트

기존 종목 뷰는 모바일 카드 / PC 표를 따로 뒀는데, 팀 묶음은 **중첩 구조**라 flat table과 맞지 않아 **한 가지 반응형 레이아웃으로 통일**했습니다. PC에서 표 형태를 유지하는 편이 낫다면 알려주세요.

생년월일은 저장 포맷 그대로(`1990-03-15`) 노출합니다. `19900315`나 만 나이 표기를 선호하면 `calculateAgeGroup` 유틸로 바꿀 수 있습니다.

## 검증

- 신규 테스트 20건 전부 통과, 변경 파일 lint·tsc 클린.
- `sms-notification.test.ts` / `GuestPageStrategy.test.ts` 실패는 **이 변경 전에도 실패**하던 기존 이슈입니다. 손대지 않았습니다.

## 참고

base가 `main`이 아니라 #62(`fix/entry-required-field-messages`)입니다. 해당 PR이 먼저 머지된 뒤에 이 PR을 머지해 주세요.