### PR TITLE
fix(tournament): 신청 검증·팀 단위 현황 표시 main 반영 (#61~#63)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-prettier": "^5.2.3",
         "jest": "^30.0.5",
+        "jest-environment-jsdom": "^30.4.1",
         "postcss": "^8",
         "prettier": "^3.4.2",
         "prisma": "^6.2.1",
@@ -102,6 +103,27 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1917,6 +1939,121 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
@@ -2901,6 +3038,231 @@
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "jest-mock": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
+      "integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4433,6 +4795,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4547,6 +4921,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5355,6 +5736,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -6532,6 +6923,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -6544,6 +6949,57 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6622,6 +7078,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.6.0",
@@ -6945,6 +7408,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -8558,12 +9034,53 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -8573,6 +9090,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb": {
@@ -9031,6 +9561,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -9758,6 +10295,226 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
+      "integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/environment-jsdom-abstract": "30.4.1",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
     },
     "node_modules/jest-environment-node": {
       "version": "30.0.5",
@@ -10492,6 +11249,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -11270,6 +12104,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -11546,6 +12387,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -12181,6 +13035,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -12559,6 +13429,13 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -12652,6 +13529,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -13459,6 +14356,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
@@ -13783,6 +14687,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -13800,6 +14724,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -14379,6 +15316,19 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -14547,6 +15497,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -15117,6 +16091,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.2.3",
     "jest": "^30.0.5",
+    "jest-environment-jsdom": "^30.4.1",
     "postcss": "^8",
     "prettier": "^3.4.2",
     "prisma": "^6.2.1",

--- a/src/__tests__/components/tournament/EntrySummary.dom.test.tsx
+++ b/src/__tests__/components/tournament/EntrySummary.dom.test.tsx
@@ -78,9 +78,7 @@ describe('EntrySummary - 개인정보 동의 검증', () => {
     fireEvent.click(screen.getByText('제출'));
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
-    expect(
-      screen.queryByText('개인정보 수집·이용에 동의해주세요.')
-    ).toBeNull();
+    expect(screen.queryByText('개인정보 수집·이용에 동의해주세요.')).toBeNull();
   });
 
   it('입금자명이 비어 있으면 안내 메시지를 보여준다', async () => {

--- a/src/__tests__/components/tournament/EntrySummary.dom.test.tsx
+++ b/src/__tests__/components/tournament/EntrySummary.dom.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { type EntryFormValues } from '@/components/organisms/tournament/entry/entryFormTypes';
+import EntrySummary from '@/components/organisms/tournament/entry/EntrySummary';
+
+import type { TournamentEventType } from '@prisma/client';
+
+/**
+ * EntrySummary는 useFormContext에 의존하므로 FormProvider로 감싸 렌더링한다.
+ * 개인정보 동의 체크박스를 비운 채 제출했을 때의 피드백을 검증한다.
+ */
+function renderEntrySummary(options?: {
+  defaults?: Partial<EntryFormValues>;
+  onSubmit?: (values: EntryFormValues) => void;
+}) {
+  function Wrapper() {
+    const methods = useForm<EntryFormValues>({
+      defaultValues: {
+        depositorName: '',
+        teamName: '',
+        players: [],
+        events: [],
+        privacyAgreed: false,
+        ...options?.defaults,
+      },
+    });
+
+    return (
+      <FormProvider {...methods}>
+        <form
+          onSubmit={methods.handleSubmit((values) =>
+            options?.onSubmit?.(values)
+          )}
+        >
+          <EntrySummary
+            eventTypes={[] as unknown as TournamentEventType[]}
+            useTeamName={false}
+            bankAccount={null}
+          />
+          <button type="submit">제출</button>
+        </form>
+      </FormProvider>
+    );
+  }
+
+  return render(<Wrapper />);
+}
+
+describe('EntrySummary - 개인정보 동의 검증', () => {
+  it('체크박스를 비운 채 제출하면 안내 메시지를 보여주고 제출을 막는다', async () => {
+    const onSubmit = jest.fn();
+    renderEntrySummary({ defaults: { depositorName: '홍길동' }, onSubmit });
+
+    fireEvent.click(screen.getByText('제출'));
+
+    // required: true(boolean)였을 때는 메시지가 빈 문자열이라
+    // 버튼을 눌러도 아무 반응이 없는 것처럼 보였다.
+    expect(
+      await screen.findByText('개인정보 수집·이용에 동의해주세요.')
+    ).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('체크하면 메시지가 사라지고 제출된다', async () => {
+    const onSubmit = jest.fn();
+    renderEntrySummary({ defaults: { depositorName: '홍길동' }, onSubmit });
+
+    fireEvent.click(screen.getByText('제출'));
+    expect(
+      await screen.findByText('개인정보 수집·이용에 동의해주세요.')
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByText('제출'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(
+      screen.queryByText('개인정보 수집·이용에 동의해주세요.')
+    ).toBeNull();
+  });
+
+  it('입금자명이 비어 있으면 안내 메시지를 보여준다', async () => {
+    const onSubmit = jest.fn();
+    renderEntrySummary({ defaults: { privacyAgreed: true }, onSubmit });
+
+    fireEvent.click(screen.getByText('제출'));
+
+    expect(await screen.findByText('입금자명을 입력해주세요.')).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
+++ b/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import EventGroupList from '@/components/organisms/tournament/admin/EventGroupList';
+
+import type { EventGroup } from '@/lib/tournament/groupEntriesByEvent';
+
+const 남자복식: EventGroup = {
+  label: '남자복식 30대 A조',
+  playerCount: 4,
+  teams: [
+    {
+      entryId: 'e1',
+      depositorName: '김철수',
+      teamName: '무적클럽',
+      paymentStatus: 'CONFIRMED',
+      players: [
+        {
+          name: '김철수',
+          birthDate: '1990-03-15',
+          phoneNumber: '010-1111-1111',
+          tshirtSize: 'L',
+        },
+        {
+          name: '박영희',
+          birthDate: '1992-07-01',
+          phoneNumber: '010-2222-2222',
+          tshirtSize: null,
+        },
+      ],
+    },
+    {
+      entryId: 'e2',
+      depositorName: '이민수',
+      teamName: null,
+      paymentStatus: 'PENDING',
+      players: [
+        {
+          name: '이민수',
+          birthDate: '1988-05-05',
+          phoneNumber: '010-3333-3333',
+          tshirtSize: 'M',
+        },
+        {
+          name: '정다은',
+          birthDate: '1995-12-25',
+          phoneNumber: '010-4444-4444',
+          tshirtSize: 'S',
+        },
+      ],
+    },
+  ],
+};
+
+describe('EventGroupList', () => {
+  it('종목 제목에 팀 수와 인원 수를 함께 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    expect(screen.getByText('남자복식 30대 A조')).toBeTruthy();
+    expect(screen.getByText('2팀 / 4명')).toBeTruthy();
+  });
+
+  it('파트너 이름을 한 줄에 묶어 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    // 평평한 목록이었다면 이름이 각각 흩어져 팀을 알 수 없었다.
+    expect(screen.getByText('김철수 · 박영희')).toBeTruthy();
+    expect(screen.getByText('이민수 · 정다은')).toBeTruthy();
+  });
+
+  it('팀마다 신청서의 입금 상태를 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    expect(screen.getByText('입금확인')).toBeTruthy();
+    expect(screen.getByText('입금대기')).toBeTruthy();
+  });
+
+  it('선수별 생년월일·연락처·티셔츠를 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    // 연령부 자격 확인에 생년월일이 필요하다.
+    expect(screen.getByText('1990-03-15')).toBeTruthy();
+    expect(screen.getByText('1992-07-01')).toBeTruthy();
+    expect(screen.getByText('010-1111-1111')).toBeTruthy();
+    expect(screen.getByText('티셔츠 L')).toBeTruthy();
+    // 티셔츠를 안 쓰는 대회는 값이 없으므로 '-'로 채운다.
+    expect(screen.getByText('티셔츠 -')).toBeTruthy();
+  });
+
+  it('useTeamName이 켜져 있으면 팀명을 보여준다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName />);
+
+    expect(screen.getByText('(무적클럽)')).toBeTruthy();
+  });
+
+  it('useTeamName이 꺼져 있으면 팀명을 숨긴다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    expect(screen.queryByText('(무적클럽)')).toBeNull();
+  });
+
+  it('단식은 이름 하나만 보여준다', () => {
+    const 단식: EventGroup = {
+      label: '남자단식 30대 A조',
+      playerCount: 1,
+      teams: [
+        {
+          entryId: 'e1',
+          depositorName: '김철수',
+          teamName: null,
+          paymentStatus: 'PENDING',
+          players: [
+            {
+              name: '김철수',
+              birthDate: '1990-03-15',
+              phoneNumber: '010-1111-1111',
+              tshirtSize: 'L',
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<EventGroupList groups={[단식]} useTeamName={false} />);
+
+    // 팀 이름 줄과 선수 상세 줄에 각각 한 번씩 나온다. 가운뎃점은 없어야 한다.
+    expect(screen.getAllByText('김철수')).toHaveLength(2);
+    expect(screen.queryByText(/·/)).toBeNull();
+    expect(screen.getByText('1팀 / 1명')).toBeTruthy();
+  });
+
+  it('묶음이 없으면 안내 문구를 보여준다', () => {
+    render(<EventGroupList groups={[]} useTeamName={false} />);
+
+    expect(screen.getByText('신청 내역이 없습니다.')).toBeTruthy();
+  });
+});

--- a/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
+++ b/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
@@ -58,6 +58,13 @@ function getBirthDateInput(index = 0): HTMLInputElement {
   ] as HTMLInputElement;
 }
 
+/** n번째 선수의 전화번호 입력창을 가져온다. */
+function getPhoneNumberInput(index = 0): HTMLInputElement {
+  return screen.getAllByPlaceholderText('010-1234-5678')[
+    index
+  ] as HTMLInputElement;
+}
+
 describe('PlayerListField - 생년월일 입력', () => {
   it('달력 위젯 대신 숫자 키패드를 띄우는 텍스트 입력으로 렌더링한다', () => {
     renderPlayerListField();
@@ -105,6 +112,67 @@ describe('PlayerListField - 생년월일 입력', () => {
   });
 });
 
+describe('PlayerListField - 전화번호 입력', () => {
+  it('숫자 키패드를 띄우고 하이픈 포함 길이로 제한한다', () => {
+    renderPlayerListField();
+    const input = getPhoneNumberInput();
+
+    expect(input.getAttribute('inputmode')).toBe('numeric');
+    expect(input.getAttribute('maxlength')).toBe('13');
+  });
+
+  it('숫자만 입력해도 하이픈을 붙여 보여준다', () => {
+    renderPlayerListField();
+    const input = getPhoneNumberInput();
+
+    fireEvent.change(input, { target: { value: '01012345678' } });
+
+    expect(input.value).toBe('010-1234-5678');
+  });
+
+  it('입력 중에도 자리 수에 맞춰 하이픈을 붙인다', () => {
+    renderPlayerListField();
+    const input = getPhoneNumberInput();
+
+    fireEvent.change(input, { target: { value: '0101' } });
+
+    expect(input.value).toBe('010-1');
+  });
+
+  it('11자리를 넘겨 입력해도 잘라낸다', () => {
+    renderPlayerListField();
+    const input = getPhoneNumberInput();
+
+    fireEvent.change(input, { target: { value: '010123456789999' } });
+
+    expect(input.value).toBe('010-1234-5678');
+  });
+
+  it('자동 채움된 하이픈 값을 그대로 표시한다', () => {
+    renderPlayerListField({ players: [{ phoneNumber: '010-1111-2222' }] });
+
+    expect(getPhoneNumberInput().value).toBe('010-1111-2222');
+  });
+
+  it('저장 값은 숫자만 남긴 형태로 제출한다', async () => {
+    const onSubmit = jest.fn();
+    renderPlayerListField({
+      players: [{ name: '홍길동', gender: '남', birthDate: '1990-03-15' }],
+      onSubmit,
+    });
+
+    fireEvent.change(getPhoneNumberInput(), {
+      target: { value: '010-1234-5678' },
+    });
+    fireEvent.click(screen.getByText('제출'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+
+    const submitted = onSubmit.mock.calls[0][0] as EntryFormValues;
+    expect(submitted.players[0].phoneNumber).toBe('01012345678');
+  });
+});
+
 describe('PlayerListField - 검증 메시지', () => {
   let onSubmit: jest.Mock;
 
@@ -143,6 +211,32 @@ describe('PlayerListField - 검증 메시지', () => {
     fireEvent.click(screen.getByText('제출'));
 
     expect(await screen.findByText('올바른 생년월일이 아닙니다.')).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('자릿수가 모자란 전화번호를 거부한다', async () => {
+    renderPlayerListField({ onSubmit });
+
+    fireEvent.change(getPhoneNumberInput(), { target: { value: '010-1234' } });
+    fireEvent.click(screen.getByText('제출'));
+
+    expect(
+      await screen.findByText('올바른 전화번호가 아닙니다. (예: 010-1234-5678)')
+    ).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('휴대폰 국번이 아닌 번호를 거부한다', async () => {
+    renderPlayerListField({ onSubmit });
+
+    fireEvent.change(getPhoneNumberInput(), {
+      target: { value: '02-1234-5678' },
+    });
+    fireEvent.click(screen.getByText('제출'));
+
+    expect(
+      await screen.findByText('올바른 전화번호가 아닙니다. (예: 010-1234-5678)')
+    ).toBeTruthy();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/src/components/organisms/tournament/admin/EventGroupList.tsx
+++ b/src/components/organisms/tournament/admin/EventGroupList.tsx
@@ -1,0 +1,92 @@
+import { PAYMENT_CLASS, PAYMENT_LABEL } from '@/lib/tournament/display';
+import type {
+  EventGroup,
+  GroupedTeam,
+} from '@/lib/tournament/groupEntriesByEvent';
+
+interface EventGroupListProps {
+  groups: EventGroup[];
+  useTeamName: boolean;
+}
+
+/** 팀을 이룬 선수를 '이름 · 이름' 형태로 잇는다. 단식이면 이름 하나만 남는다. */
+function TeamPlayerNames({ team }: { team: GroupedTeam }) {
+  return (
+    <span className="font-medium">
+      {team.players.map((player) => player.name).join(' · ')}
+    </span>
+  );
+}
+
+function EventGroupList({ groups, useTeamName }: EventGroupListProps) {
+  if (groups.length === 0) {
+    return (
+      <p className="rounded-md bg-gray-50 p-6 text-center text-sm text-gray-500">
+        신청 내역이 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {groups.map((group) => (
+        <section
+          key={group.label}
+          className="rounded-lg border border-gray-200 p-4"
+        >
+          <h3 className="mb-3 font-medium">
+            {group.label}{' '}
+            <span className="text-sm text-gray-400">
+              {group.teams.length}팀 / {group.playerCount}명
+            </span>
+          </h3>
+
+          <ul className="space-y-2">
+            {group.teams.map((team, index) => (
+              <li
+                key={`${team.entryId}-${index}`}
+                className="rounded-md bg-gray-50 p-3"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-1">
+                  <div className="flex items-baseline gap-2">
+                    {/* 팀 번호가 있어야 인원이 많은 종목에서 줄을 세어 읽기 쉽다. */}
+                    <span className="text-xs text-gray-400">{index + 1}</span>
+                    <TeamPlayerNames team={team} />
+                    {useTeamName && team.teamName && (
+                      <span className="text-xs text-gray-500">
+                        ({team.teamName})
+                      </span>
+                    )}
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-full px-2 py-0.5 text-xs ${PAYMENT_CLASS[team.paymentStatus]}`}
+                  >
+                    {PAYMENT_LABEL[team.paymentStatus]}
+                  </span>
+                </div>
+
+                {/* 연락처·티셔츠는 한 단계 낮춰 팀 경계가 먼저 읽히게 한다. */}
+                <ul className="mt-1 space-y-0.5 pl-5">
+                  {team.players.map((player, playerIndex) => (
+                    <li
+                      key={`${player.name}-${playerIndex}`}
+                      className="flex flex-wrap items-baseline gap-x-2 text-xs text-gray-500"
+                    >
+                      <span>{player.name}</span>
+                      {/* 연령부 자격을 확인하려면 관리자에게 생년월일이 필요하다. */}
+                      <span>{player.birthDate || '-'}</span>
+                      <span>{player.phoneNumber}</span>
+                      <span>티셔츠 {player.tshirtSize ?? '-'}</span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export default EventGroupList;

--- a/src/components/organisms/tournament/entry/EntrySummary.tsx
+++ b/src/components/organisms/tournament/entry/EntrySummary.tsx
@@ -19,7 +19,11 @@ function EntrySummary({
   useTeamName,
   bankAccount,
 }: EntrySummaryProps) {
-  const { register, watch } = useFormContext<EntryFormValues>();
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext<EntryFormValues>();
 
   const events = watch('events') ?? [];
   const feeById = new Map(
@@ -48,11 +52,17 @@ function EntrySummary({
         )}
       </div>
 
-      <FormField label="입금자명" required>
+      <FormField
+        label="입금자명"
+        required
+        error={errors.depositorName?.message}
+      >
         <Input
           type="text"
           placeholder="통장에 찍히는 이름을 적어주세요"
-          {...register('depositorName', { required: true })}
+          {...register('depositorName', {
+            required: '입금자명을 입력해주세요.',
+          })}
         />
       </FormField>
 
@@ -62,19 +72,28 @@ function EntrySummary({
         </FormField>
       )}
 
-      <label className="flex items-start gap-2 text-sm text-gray-700">
-        <input
-          type="checkbox"
-          className="mt-1"
-          {...register('privacyAgreed', { required: true })}
-        />
-        <span>
-          개인정보 수집·이용에 동의합니다. 수집한 정보(이름, 생년월일,
-          전화번호)는 대회 참가 신청 목적으로만 사용되며 주최측에 제출됩니다.
-          본인 외 선수의 정보를 입력한 경우 해당 선수의 동의를 받았음을
-          확인합니다.
-        </span>
-      </label>
+      <div className="space-y-1">
+        <label className="flex items-start gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            className="mt-1"
+            {...register('privacyAgreed', {
+              required: '개인정보 수집·이용에 동의해주세요.',
+            })}
+          />
+          <span>
+            개인정보 수집·이용에 동의합니다. 수집한 정보(이름, 생년월일,
+            전화번호)는 대회 참가 신청 목적으로만 사용되며 주최측에 제출됩니다.
+            본인 외 선수의 정보를 입력한 경우 해당 선수의 동의를 받았음을
+            확인합니다.
+          </span>
+        </label>
+        {errors.privacyAgreed && (
+          <p role="alert" className="text-sm text-red-500">
+            {errors.privacyAgreed.message}
+          </p>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/components/organisms/tournament/entry/EventListField.tsx
+++ b/src/components/organisms/tournament/entry/EventListField.tsx
@@ -19,8 +19,13 @@ function EventListField({
   ageGroups,
   levels,
 }: EventListFieldProps) {
-  const { control, register, watch, setValue } =
-    useFormContext<EntryFormValues>();
+  const {
+    control,
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useFormContext<EntryFormValues>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'events',
@@ -61,6 +66,7 @@ function EventListField({
         const selected = events[index];
         const eventType = typeById.get(selected?.eventTypeId ?? '');
         const playerCount = eventType?.playerCount ?? 0;
+        const eventErrors = errors.events?.[index];
 
         const playerOptions = players.map((player, i) => ({
           value: player.key,
@@ -99,29 +105,46 @@ function EventListField({
               />
             </FormField>
 
-            <FormField label="연령" required>
+            <FormField
+              label="연령"
+              required
+              error={eventErrors?.ageGroup?.message}
+            >
               <Select
                 options={ageOptions}
-                {...register(`events.${index}.ageGroup`, { required: true })}
+                {...register(`events.${index}.ageGroup`, {
+                  required: '연령을 선택해주세요.',
+                })}
               />
             </FormField>
 
             {usesLevel && (
-              <FormField label="급수" required>
+              <FormField
+                label="급수"
+                required
+                error={eventErrors?.level?.message}
+              >
                 <Select
                   options={levelOptions}
-                  {...register(`events.${index}.level`, { required: true })}
+                  {...register(`events.${index}.level`, {
+                    required: '급수를 선택해주세요.',
+                  })}
                 />
               </FormField>
             )}
 
             {playerCount > 0 &&
               Array.from({ length: playerCount }).map((_, slot) => (
-                <FormField key={slot} label={`선수 ${slot + 1}`} required>
+                <FormField
+                  key={slot}
+                  label={`선수 ${slot + 1}`}
+                  required
+                  error={eventErrors?.playerKeys?.[slot]?.message}
+                >
                   <Select
                     options={playerOptions}
                     {...register(`events.${index}.playerKeys.${slot}`, {
-                      required: true,
+                      required: '선수를 선택해주세요.',
                     })}
                   />
                 </FormField>

--- a/src/components/organisms/tournament/entry/PlayerListField.tsx
+++ b/src/components/organisms/tournament/entry/PlayerListField.tsx
@@ -9,6 +9,11 @@ import {
   toBirthDateDigits,
   toIsoBirthDate,
 } from '@/utils/birthDate';
+import {
+  formatPhoneNumber,
+  getPhoneNumberError,
+  toPhoneDigits,
+} from '@/utils/phoneNumber';
 
 import {
   createEmptyPlayer,
@@ -166,12 +171,27 @@ function PlayerListField({ tshirtSizes }: PlayerListFieldProps) {
                 required
                 error={playerErrors?.phoneNumber?.message}
               >
-                <Input
-                  type="tel"
-                  placeholder="010-1234-5678"
-                  {...register(`players.${index}.phoneNumber`, {
-                    required: '전화번호를 입력해주세요.',
-                  })}
+                <Controller
+                  control={control}
+                  name={`players.${index}.phoneNumber`}
+                  rules={{ validate: getPhoneNumberError }}
+                  render={({ field }) => (
+                    <Input
+                      type="tel"
+                      inputMode="numeric"
+                      autoComplete="tel"
+                      // '010-1234-5678' = 13자. 하이픈은 자동으로 붙는다.
+                      maxLength={13}
+                      placeholder="010-1234-5678"
+                      // 숫자만 입력해도 하이픈이 붙은 형태로 보여준다.
+                      value={formatPhoneNumber(field.value)}
+                      onChange={(event) =>
+                        field.onChange(toPhoneDigits(event.target.value))
+                      }
+                      onBlur={field.onBlur}
+                      ref={field.ref}
+                    />
+                  )}
                 />
               </FormField>
 

--- a/src/lib/tournament/groupEntriesByEvent.test.ts
+++ b/src/lib/tournament/groupEntriesByEvent.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { EntryPaymentStatus } from '@/types/tournament.types';
+
+import { groupEntriesByEvent } from './groupEntriesByEvent';
+
+/** 테스트마다 필요한 부분만 덮어쓰도록 최소 신청서를 만든다. */
+function createEntry(options: {
+  id: string;
+  depositorName?: string;
+  teamName?: string | null;
+  paymentStatus?: EntryPaymentStatus;
+  events: Array<{
+    eventType?: string;
+    ageGroup?: string;
+    level?: string;
+    status?: string;
+    players: string[];
+  }>;
+}) {
+  return {
+    id: options.id,
+    depositorName: options.depositorName ?? '입금자',
+    teamName: options.teamName ?? null,
+    paymentStatus: options.paymentStatus ?? ('PENDING' as EntryPaymentStatus),
+    entryEvents: options.events.map((event) => ({
+      status: event.status ?? 'ACTIVE',
+      ageGroup: event.ageGroup ?? '30대',
+      level: event.level ?? 'A조',
+      eventType: { name: event.eventType ?? '남자복식' },
+      eventPlayers: event.players.map((name) => ({
+        entryPlayer: {
+          name,
+          birthDate: '1990-03-15',
+          phoneNumber: `010-0000-000${name.length}`,
+          tshirtSize: null,
+        },
+      })),
+    })),
+  };
+}
+
+describe('groupEntriesByEvent', () => {
+  it('같은 종목의 신청을 하나로 묶는다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수', '박영희'] }] }),
+      createEntry({ id: 'e2', events: [{ players: ['이민수', '정다은'] }] }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('남자복식 30대 A조');
+    expect(result[0].teams).toHaveLength(2);
+  });
+
+  it('복식 파트너를 한 팀으로 유지한다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수', '박영희'] }] }),
+      createEntry({ id: 'e2', events: [{ players: ['이민수', '정다은'] }] }),
+    ]);
+
+    // 평평하게 폈다면 4명이 한 줄로 늘어서 팀 경계를 알 수 없다.
+    expect(result[0].teams[0].players.map((p) => p.name)).toEqual([
+      '김철수',
+      '박영희',
+    ]);
+    expect(result[0].teams[1].players.map((p) => p.name)).toEqual([
+      '이민수',
+      '정다은',
+    ]);
+  });
+
+  it('종목이 다르면 서로 다른 묶음으로 나눈다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [
+          { players: ['김철수', '박영희'] },
+          { eventType: '혼합복식', players: ['김철수', '정다은'] },
+        ],
+      }),
+    ]);
+
+    expect(result.map((group) => group.label)).toEqual([
+      '남자복식 30대 A조',
+      '혼합복식 30대 A조',
+    ]);
+  });
+
+  it('같은 종목이라도 연령·급수가 다르면 나눈다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수', '박영희'] }] }),
+      createEntry({
+        id: 'e2',
+        events: [{ ageGroup: '40대', players: ['이민수', '정다은'] }],
+      }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('취소된 종목은 제외한다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [{ status: 'CANCELED', players: ['김철수', '박영희'] }],
+      }),
+    ]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('한 신청서가 같은 종목에 여러 팀을 내면 각각 별도 팀으로 쌓는다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [
+          { players: ['김철수', '박영희'] },
+          { players: ['이민수', '정다은'] },
+        ],
+      }),
+    ]);
+
+    expect(result[0].teams).toHaveLength(2);
+    expect(result[0].teams.every((team) => team.entryId === 'e1')).toBe(true);
+  });
+
+  it('단식은 한 팀에 한 명으로 묶는다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [{ eventType: '남자단식', players: ['김철수'] }],
+      }),
+    ]);
+
+    expect(result[0].teams[0].players).toHaveLength(1);
+  });
+
+  it('종목별 총 인원을 센다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수', '박영희'] }] }),
+      createEntry({ id: 'e2', events: [{ players: ['이민수', '정다은'] }] }),
+      createEntry({ id: 'e3', events: [{ players: ['홍길동', '손흥민'] }] }),
+    ]);
+
+    expect(result[0].teams).toHaveLength(3);
+    expect(result[0].playerCount).toBe(6);
+  });
+
+  it('팀에 신청서의 입금 상태와 입금자명을 남긴다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        depositorName: '김철수',
+        paymentStatus: 'CONFIRMED',
+        events: [{ players: ['김철수', '박영희'] }],
+      }),
+    ]);
+
+    expect(result[0].teams[0].paymentStatus).toBe('CONFIRMED');
+    expect(result[0].teams[0].depositorName).toBe('김철수');
+  });
+
+  it('종목이 처음 등장한 순서를 유지한다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({
+        id: 'e1',
+        events: [
+          { eventType: '혼합복식', players: ['김철수', '정다은'] },
+          { eventType: '남자복식', players: ['김철수', '박영희'] },
+        ],
+      }),
+    ]);
+
+    expect(result.map((group) => group.label)).toEqual([
+      '혼합복식 30대 A조',
+      '남자복식 30대 A조',
+    ]);
+  });
+
+  it('선수의 생년월일을 함께 넘긴다', () => {
+    const result = groupEntriesByEvent([
+      createEntry({ id: 'e1', events: [{ players: ['김철수'] }] }),
+    ]);
+
+    expect(result[0].teams[0].players[0].birthDate).toBe('1990-03-15');
+  });
+
+  it('빈 목록이면 빈 배열을 반환한다', () => {
+    expect(groupEntriesByEvent([])).toEqual([]);
+  });
+});

--- a/src/lib/tournament/groupEntriesByEvent.ts
+++ b/src/lib/tournament/groupEntriesByEvent.ts
@@ -1,0 +1,102 @@
+import type { EntryPaymentStatus } from '@/types/tournament.types';
+
+import { formatEventLabel } from './display';
+
+/** 종목 묶음 안에서 한 팀을 이루는 선수 한 명. */
+export interface GroupedPlayer {
+  name: string;
+  birthDate: string;
+  phoneNumber: string;
+  tshirtSize: string | null;
+}
+
+/**
+ * 한 신청서가 한 종목에 낸 팀 하나.
+ * 복식이면 players가 2명, 단식이면 1명이다.
+ */
+export interface GroupedTeam {
+  entryId: string;
+  depositorName: string;
+  teamName: string | null;
+  paymentStatus: EntryPaymentStatus;
+  players: GroupedPlayer[];
+}
+
+/** 종목 하나에 모인 팀 목록. */
+export interface EventGroup {
+  label: string;
+  teams: GroupedTeam[];
+  playerCount: number;
+}
+
+/** 그룹핑에 필요한 최소 형태만 받는다. Prisma 전체 타입에 묶이지 않게 한다. */
+interface GroupableEntry {
+  id: string;
+  depositorName: string;
+  teamName: string | null;
+  paymentStatus: EntryPaymentStatus;
+  entryEvents: Array<{
+    status: string;
+    ageGroup: string;
+    level: string;
+    eventType: { name: string };
+    eventPlayers: Array<{
+      entryPlayer: {
+        name: string;
+        birthDate: string;
+        phoneNumber: string;
+        tshirtSize: string | null;
+      };
+    }>;
+  }>;
+}
+
+/**
+ * 신청 목록을 종목별로 묶고, 종목 안에서는 다시 팀 단위로 묶는 함수
+ *
+ * 선수를 평평하게 늘어놓으면 복식에서 누가 누구와 한 팀인지 알 수 없다.
+ * 신청서 하나가 한 종목에 낸 eventPlayers가 곧 한 팀이므로, 그 경계를
+ * 유지한 채로 쌓는다.
+ *
+ * 취소(CANCELED)된 종목은 제외한다. 신청서 자체의 입금 상태는 팀에 남겨
+ * 화면에서 배지로 보여준다.
+ *
+ * @param entries - 관리자용 신청 목록
+ * @returns 종목별 묶음 배열. 종목이 처음 등장한 순서를 유지한다.
+ */
+export function groupEntriesByEvent(entries: GroupableEntry[]): EventGroup[] {
+  const groups = new Map<string, GroupedTeam[]>();
+
+  for (const entry of entries) {
+    for (const event of entry.entryEvents) {
+      if (event.status !== 'ACTIVE') continue;
+
+      const label = formatEventLabel({
+        eventType: event.eventType.name,
+        ageGroup: event.ageGroup,
+        level: event.level,
+      });
+
+      const teams = groups.get(label) ?? [];
+      teams.push({
+        entryId: entry.id,
+        depositorName: entry.depositorName,
+        teamName: entry.teamName,
+        paymentStatus: entry.paymentStatus,
+        players: event.eventPlayers.map((eventPlayer) => ({
+          name: eventPlayer.entryPlayer.name,
+          birthDate: eventPlayer.entryPlayer.birthDate,
+          phoneNumber: eventPlayer.entryPlayer.phoneNumber,
+          tshirtSize: eventPlayer.entryPlayer.tshirtSize,
+        })),
+      });
+      groups.set(label, teams);
+    }
+  }
+
+  return Array.from(groups.entries()).map(([label, teams]) => ({
+    label,
+    teams,
+    playerCount: teams.reduce((sum, team) => sum + team.players.length, 0),
+  }));
+}

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/admin.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/admin.tsx
@@ -6,6 +6,7 @@ import toast from 'react-hot-toast';
 
 import DeleteTournamentDialog from '@/components/organisms/tournament/admin/DeleteTournamentDialog';
 import EntryTable from '@/components/organisms/tournament/admin/EntryTable';
+import EventGroupList from '@/components/organisms/tournament/admin/EventGroupList';
 
 import {
   useAdminEntries,
@@ -14,7 +15,8 @@ import {
 } from '@/hooks/useTournamentAdmin';
 import { useTournamentDetail } from '@/hooks/useTournamentDetail';
 
-import { formatEventLabel, formatFee } from '@/lib/tournament/display';
+import { formatFee } from '@/lib/tournament/display';
+import { groupEntriesByEvent } from '@/lib/tournament/groupEntriesByEvent';
 import type { EntryPaymentStatus } from '@/types/tournament.types';
 
 type ViewMode = 'entry' | 'event';
@@ -43,34 +45,8 @@ function TournamentAdminPage() {
     [entries, statusFilter]
   );
 
-  // 종목별 신청 인원 집계
-  const eventGroups = useMemo(() => {
-    const groups = new Map<
-      string,
-      Array<{ name: string; phoneNumber: string; tshirtSize: string | null }>
-    >();
-
-    for (const entry of filtered) {
-      for (const event of entry.entryEvents) {
-        if (event.status !== 'ACTIVE') continue;
-        const label = formatEventLabel({
-          eventType: event.eventType.name,
-          ageGroup: event.ageGroup,
-          level: event.level,
-        });
-        const list = groups.get(label) ?? [];
-        for (const eventPlayer of event.eventPlayers) {
-          list.push({
-            name: eventPlayer.entryPlayer.name,
-            phoneNumber: eventPlayer.entryPlayer.phoneNumber,
-            tshirtSize: eventPlayer.entryPlayer.tshirtSize,
-          });
-        }
-        groups.set(label, list);
-      }
-    }
-    return Array.from(groups.entries());
-  }, [filtered]);
+  // 종목별로 묶고, 종목 안에서는 다시 팀(파트너) 단위로 묶는다.
+  const eventGroups = useMemo(() => groupEntriesByEvent(filtered), [filtered]);
 
   const totalConfirmed = useMemo(
     () =>
@@ -217,70 +193,10 @@ function TournamentAdminPage() {
           onChangePaymentStatus={onChangePaymentStatus}
         />
       ) : (
-        <div className="space-y-4">
-          {eventGroups.map(([label, players]) => (
-            <section
-              key={label}
-              className="rounded-lg border border-gray-200 p-4"
-            >
-              <h3 className="mb-2 font-medium">
-                {label}{' '}
-                <span className="text-sm text-gray-400">
-                  {players.length}명
-                </span>
-              </h3>
-              {/* 모바일: 카드 목록 */}
-              <ul className="space-y-2 text-sm sm:hidden">
-                {players.map((player, index) => (
-                  <li
-                    key={`${player.name}-${index}`}
-                    className="rounded-md bg-gray-50 p-2"
-                  >
-                    <div className="flex items-baseline justify-between gap-2">
-                      <span className="font-medium">{player.name}</span>
-                      <span className="shrink-0 text-xs text-gray-500">
-                        티셔츠 {player.tshirtSize ?? '-'}
-                      </span>
-                    </div>
-                    <p className="mt-0.5 text-xs text-gray-500">
-                      {player.phoneNumber}
-                    </p>
-                  </li>
-                ))}
-              </ul>
-
-              {/* PC: 표 */}
-              <div className="hidden overflow-x-auto sm:block">
-                <table className="w-full min-w-[360px] text-sm">
-                  <thead>
-                    <tr className="border-b text-left text-gray-500">
-                      <th className="py-1">이름</th>
-                      <th className="py-1">연락처</th>
-                      <th className="py-1">티셔츠</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {players.map((player, index) => (
-                      <tr
-                        key={`${player.name}-${index}`}
-                        className="border-b last:border-0"
-                      >
-                        <td className="py-1">{player.name}</td>
-                        <td className="py-1">{player.phoneNumber}</td>
-                        <td className="py-1">{player.tshirtSize ?? '-'}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          ))}
-          {eventGroups.length === 0 && (
-            <p className="rounded-md bg-gray-50 p-6 text-center text-sm text-gray-500">
-              신청 내역이 없습니다.
-            </p>
-          )}
-        </div>
+        <EventGroupList
+          groups={eventGroups}
+          useTeamName={detail?.tournament.useTeamName ?? false}
+        />
       )}
     </div>
   );

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
@@ -167,6 +167,15 @@ function TournamentApplyPage() {
             bankAccount={detail.tournament.bankAccount}
           />
 
+          {/* 개별 필드 메시지가 화면 밖에 있으면 버튼이 먹통처럼 보인다.
+              제출 실패 사실만이라도 버튼 옆에서 알린다. */}
+          {methods.formState.submitCount > 0 && !methods.formState.isValid && (
+            <p role="alert" className="text-sm text-red-500">
+              입력하지 않은 필수 항목이 있습니다. 위 항목의 빨간 안내를
+              확인해주세요.
+            </p>
+          )}
+
           <button
             type="submit"
             disabled={submitEntry.isPending}

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { isValidBirthDate, toIsoBirthDate } from '@/utils/birthDate';
+import { formatPhoneNumber, isValidPhoneNumber } from '@/utils/phoneNumber';
 
 const eventTypeSchema = z.object({
   // 폼의 hidden input이 신규 종목에 빈 문자열을 넣으므로 undefined로 정규화한다.
@@ -72,7 +73,14 @@ const playerSchema = z.object({
     .min(1, '생년월일을 입력해주세요.')
     .transform(toIsoBirthDate)
     .refine(isValidBirthDate, '올바른 생년월일이 아닙니다.'),
-  phoneNumber: z.string().trim().min(1, '전화번호를 입력해주세요.'),
+  // 클라이언트가 숫자만 보내든 하이픈을 섞어 보내든 저장 포맷을 하나로 맞춘다.
+  // 형식까지 확인해야 문자 발송(src/lib/sms.ts) 단계에서 뒤늦게 실패하지 않는다.
+  phoneNumber: z
+    .string()
+    .trim()
+    .min(1, '전화번호를 입력해주세요.')
+    .refine(isValidPhoneNumber, '올바른 전화번호가 아닙니다.')
+    .transform(formatPhoneNumber),
   tshirtSize: z.string().trim().nullable().optional(),
   order: z.number().int().min(0).default(0),
 });

--- a/src/utils/__tests__/phoneNumber.test.ts
+++ b/src/utils/__tests__/phoneNumber.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  formatPhoneNumber,
+  getPhoneNumberError,
+  isValidPhoneNumber,
+  toPhoneDigits,
+} from '@/utils/phoneNumber';
+
+describe('toPhoneDigits', () => {
+  it('하이픈이 섞인 입력에서 숫자만 남긴다', () => {
+    expect(toPhoneDigits('010-1234-5678')).toBe('01012345678');
+  });
+
+  it('공백과 괄호도 걷어낸다', () => {
+    expect(toPhoneDigits('(010) 1234 5678')).toBe('01012345678');
+  });
+
+  it('빈 값과 null을 빈 문자열로 처리한다', () => {
+    expect(toPhoneDigits('')).toBe('');
+    expect(toPhoneDigits(null)).toBe('');
+    expect(toPhoneDigits(undefined)).toBe('');
+  });
+
+  it('11자리를 넘는 입력은 잘라낸다', () => {
+    expect(toPhoneDigits('010123456789999')).toBe('01012345678');
+  });
+});
+
+describe('formatPhoneNumber', () => {
+  it('11자리를 3-4-4로 끊는다', () => {
+    expect(formatPhoneNumber('01012345678')).toBe('010-1234-5678');
+  });
+
+  it('10자리를 3-3-4로 끊는다', () => {
+    expect(formatPhoneNumber('0111234567')).toBe('011-123-4567');
+  });
+
+  it('이미 하이픈이 붙은 값을 그대로 유지한다', () => {
+    expect(formatPhoneNumber('010-1234-5678')).toBe('010-1234-5678');
+  });
+
+  it('입력 중인 값도 자리 수에 맞춰 끊는다', () => {
+    expect(formatPhoneNumber('010')).toBe('010');
+    expect(formatPhoneNumber('0101')).toBe('010-1');
+    expect(formatPhoneNumber('0101234')).toBe('010-1234');
+  });
+
+  it('빈 값을 빈 문자열로 처리한다', () => {
+    expect(formatPhoneNumber('')).toBe('');
+    expect(formatPhoneNumber(null)).toBe('');
+  });
+});
+
+describe('isValidPhoneNumber', () => {
+  it('휴대폰 번호를 통과시킨다', () => {
+    expect(isValidPhoneNumber('010-1234-5678')).toBe(true);
+    expect(isValidPhoneNumber('01012345678')).toBe(true);
+    expect(isValidPhoneNumber('011-123-4567')).toBe(true);
+  });
+
+  it('자리 수가 모자라면 거절한다', () => {
+    // 국번을 뺀 뒷자리가 7자리는 되어야 한다.
+    expect(isValidPhoneNumber('010-123-456')).toBe(false);
+    expect(isValidPhoneNumber('0101')).toBe(false);
+  });
+
+  it('휴대폰 국번이 아니면 거절한다', () => {
+    expect(isValidPhoneNumber('02-1234-5678')).toBe(false);
+    expect(isValidPhoneNumber('070-1234-5678')).toBe(false);
+  });
+
+  it('빈 값을 거절한다', () => {
+    expect(isValidPhoneNumber('')).toBe(false);
+    expect(isValidPhoneNumber(null)).toBe(false);
+  });
+});
+
+describe('getPhoneNumberError', () => {
+  it('빈 값에 입력 안내를 돌려준다', () => {
+    expect(getPhoneNumberError('')).toBe('전화번호를 입력해주세요.');
+  });
+
+  it('형식이 어긋나면 예시를 담은 안내를 돌려준다', () => {
+    expect(getPhoneNumberError('010-1234')).toBe(
+      '올바른 전화번호가 아닙니다. (예: 010-1234-5678)'
+    );
+  });
+
+  it('유효한 번호에는 undefined를 돌려준다', () => {
+    expect(getPhoneNumberError('010-1234-5678')).toBeUndefined();
+    expect(getPhoneNumberError('01012345678')).toBeUndefined();
+  });
+});

--- a/src/utils/phoneNumber.ts
+++ b/src/utils/phoneNumber.ts
@@ -1,0 +1,63 @@
+/**
+ * 휴대폰 번호로 인정하는 형식.
+ * 010~019로 시작하고 뒤에 7~8자리가 붙는다.
+ * 문자 발송(src/lib/sms.ts)이 쓰는 규칙과 같은 형식이어야
+ * 폼을 통과한 번호가 발송 단계에서 뒤늦게 거절되지 않는다.
+ */
+const PHONE_NUMBER_PATTERN = /^01[0-9]\d{7,8}$/;
+
+/** 하이픈까지 포함한 최대 길이('010-1234-5678' = 11자리). */
+const MAX_PHONE_DIGITS = 11;
+
+/**
+ * 전화번호 입력을 숫자만 남기는 함수
+ * 사용자가 하이픈이나 공백을 섞어 넣어도 동일한 형태로 맞춘다.
+ * @param value - 사용자 입력 또는 저장된 전화번호 문자열
+ * @returns 숫자만 남긴 최대 11자리 문자열
+ */
+export const toPhoneDigits = (value?: string | null): string => {
+  if (!value) return '';
+  return value.replace(/\D/g, '').slice(0, MAX_PHONE_DIGITS);
+};
+
+/**
+ * 숫자만 있는 전화번호를 하이픈 포맷으로 바꾸는 함수
+ * 입력 중에도 자연스럽게 보이도록 자리 수에 맞춰 점진적으로 끊는다.
+ * @param value - '01012345678' 형태의 문자열 (하이픈이 섞여 있어도 된다)
+ * @returns '010-1234-5678' 형태의 문자열
+ */
+export const formatPhoneNumber = (value?: string | null): string => {
+  const digits = toPhoneDigits(value);
+  if (digits.length < 4) return digits;
+  if (digits.length < 8) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+
+  // 10자리(예: 011-123-4567)는 가운데가 3자리, 11자리는 4자리다.
+  const middleLength = digits.length === 10 ? 3 : 4;
+  return `${digits.slice(0, 3)}-${digits.slice(3, 3 + middleLength)}-${digits.slice(3 + middleLength)}`;
+};
+
+/**
+ * 전화번호가 유효한지 검사하는 함수
+ * @param value - 하이픈이 있든 없든 상관없는 전화번호 문자열
+ * @returns 유효하면 true
+ */
+export const isValidPhoneNumber = (value?: string | null): boolean =>
+  PHONE_NUMBER_PATTERN.test(toPhoneDigits(value));
+
+/**
+ * 전화번호 입력값에 대한 오류 메시지를 돌려주는 함수
+ * 폼에서 react-hook-form의 validate에 그대로 연결해 쓴다.
+ * @param value - 사용자가 입력한 문자열
+ * @returns 오류 메시지. 유효하면 undefined
+ */
+export const getPhoneNumberError = (
+  value?: string | null
+): string | undefined => {
+  const digits = toPhoneDigits(value);
+
+  if (digits.length === 0) return '전화번호를 입력해주세요.';
+  if (!isValidPhoneNumber(digits))
+    return '올바른 전화번호가 아닙니다. (예: 010-1234-5678)';
+
+  return undefined;
+};


### PR DESCRIPTION
## 배경 (Why)

PR #61, #62, #63이 스택형으로 작업되면서 base 브랜치가 `main`이 아닌 **직전 작업 브랜치**로 지정된 채 머지됐다.

| PR | 머지된 대상 |
| --- | --- |
| #61 | `fix/entry-canceled-reapply-label` |
| #62 | `fix/entry-phone-number-validation` |
| #63 | `fix/entry-required-field-messages` |

GitHub에는 "Merged"로 표시되지만 실제로는 `main`에 반영되지 않아, Vercel production 배포도 트리거되지 않았다. 세 PR의 커밋은 모두 `fix/entry-required-field-messages` 브랜치에 쌓여 있는 상태였다.

또한 해당 브랜치는 `01906d1` 시점에서 갈라져 나와, 이후 `main`에 머지된 PR #55~#60을 모르는 상태였다. 그대로 올리면 PR #59가 추가한 `toLocalDateString` 등이 되돌아가는 회귀가 발생한다.

## 작업 (What)

- `fix/entry-required-field-messages`에서 통합 브랜치를 만들고 `origin/main`을 머지해 회귀를 제거 (충돌 없음)
- PR #61~#63의 변경을 한 번에 `main`으로 반영

포함되는 변경:

- **#61** 선수 전화번호 형식 검증 추가 (`src/utils/phoneNumber.ts`)
- **#62** 필수 항목 미입력 시 안내 메시지 표시
- **#63** 종목 단위 현황을 팀 단위로 묶어 표시 (`src/lib/tournament/groupEntriesByEvent.ts`)
- `.dom.test.tsx` 실행을 위한 `jest-environment-jsdom` devDependency 추가

## 검증

- `npm run build` 성공 (타입 에러 없음)
- 테스트: 245 passed / 16 failed
  - 실패 16건은 `GuestPageStrategy.test.ts`, `sms-notification.test.ts`로 **이번 변경과 무관**.
    `origin/main`에서도 동일하게 16건 실패하는 것을 확인한 기존 이슈 (Prisma mock 관련).
- `main` 대비 diff에 회귀 삭제 없음 (tournament 관련 추가분만 존재)
