### PR TITLE
feat(tournament): 외부 선수 참가비 추가금 계산 및 팀 구성 제한

### DIFF
--- a/prisma/migrations/20260822000000_add_tournament_non_member_surcharge/migration.sql
+++ b/prisma/migrations/20260822000000_add_tournament_non_member_surcharge/migration.sql
@@ -1,0 +1,10 @@
+-- 비회원 참가비 추가금 기능
+-- 세 컬럼 모두 기본값이 있어 기존 데이터에 영향이 없다.
+-- nonMemberSurcharge = 0 이면 기존 대회와 동일하게 동작한다.
+
+-- AlterTable
+ALTER TABLE "Tournament" ADD COLUMN     "memberLabel" TEXT,
+ADD COLUMN     "nonMemberSurcharge" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "EntryPlayer" ADD COLUMN     "isLocalMember" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20260823000000_add_entry_player_is_club_member/migration.sql
+++ b/prisma/migrations/20260823000000_add_entry_player_is_club_member/migration.sql
@@ -1,5 +1,0 @@
--- 선수의 우리 클럽 소속 여부 (명단 파악용, 금액과 무관)
--- 기본값이 있어 기존 선수 32건은 모두 true(내부)로 채워진다.
-
--- AlterTable
-ALTER TABLE "EntryPlayer" ADD COLUMN     "isClubMember" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20260823000000_add_entry_player_is_club_member/migration.sql
+++ b/prisma/migrations/20260823000000_add_entry_player_is_club_member/migration.sql
@@ -1,0 +1,5 @@
+-- 선수의 우리 클럽 소속 여부 (명단 파악용, 금액과 무관)
+-- 기본값이 있어 기존 선수 32건은 모두 true(내부)로 채워진다.
+
+-- AlterTable
+ALTER TABLE "EntryPlayer" ADD COLUMN     "isClubMember" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20260823010000_rename_is_local_member_to_is_club_member/migration.sql
+++ b/prisma/migrations/20260823010000_rename_is_local_member_to_is_club_member/migration.sql
@@ -1,13 +1,18 @@
 -- isLocalMember를 isClubMember로 일원화한다.
--- 두 컬럼이 사실상 같은 의미로 쓰이고 있어 혼용을 없앤다.
+-- '영등포구 회원'과 '당산클럽 소속'을 각각 가리키던 두 이름이 사실상
+-- 같은 의미로 쓰이고 있어 혼용을 없앤다.
 --
--- isClubMember 컬럼은 이미 존재하며 전부 기본값 true 상태다.
--- 실제 값은 isLocalMember에만 들어있으므로(외부 선수 7건),
--- 반드시 값을 옮긴 뒤에 옛 컬럼을 지운다.
+-- 값(외부 선수 표시)을 반드시 옮긴 뒤에 옛 컬럼을 지운다.
 -- migrate diff는 DROP만 출력하므로 그대로 쓰면 데이터가 사라진다.
 
--- 1) 값 이동
+-- 1) 새 컬럼 생성
+--    운영 DB에는 이미 만들어져 있어 IF NOT EXISTS로 재실행에 안전하게 둔다.
+--    (해당 컬럼을 추가하던 마이그레이션은 기능 revert 때 함께 지워졌다)
+ALTER TABLE "EntryPlayer"
+  ADD COLUMN IF NOT EXISTS "isClubMember" BOOLEAN NOT NULL DEFAULT true;
+
+-- 2) 값 이동
 UPDATE "EntryPlayer" SET "isClubMember" = "isLocalMember";
 
--- 2) 옛 컬럼 제거
+-- 3) 옛 컬럼 제거
 ALTER TABLE "EntryPlayer" DROP COLUMN "isLocalMember";

--- a/prisma/migrations/20260823010000_rename_is_local_member_to_is_club_member/migration.sql
+++ b/prisma/migrations/20260823010000_rename_is_local_member_to_is_club_member/migration.sql
@@ -1,0 +1,13 @@
+-- isLocalMember를 isClubMember로 일원화한다.
+-- 두 컬럼이 사실상 같은 의미로 쓰이고 있어 혼용을 없앤다.
+--
+-- isClubMember 컬럼은 이미 존재하며 전부 기본값 true 상태다.
+-- 실제 값은 isLocalMember에만 들어있으므로(외부 선수 7건),
+-- 반드시 값을 옮긴 뒤에 옛 컬럼을 지운다.
+-- migrate diff는 DROP만 출력하므로 그대로 쓰면 데이터가 사라진다.
+
+-- 1) 값 이동
+UPDATE "EntryPlayer" SET "isClubMember" = "isLocalMember";
+
+-- 2) 옛 컬럼 제거
+ALTER TABLE "EntryPlayer" DROP COLUMN "isLocalMember";

--- a/prisma/migrations/20260823020000_add_min_club_members_per_team/migration.sql
+++ b/prisma/migrations/20260823020000_add_min_club_members_per_team/migration.sql
@@ -1,0 +1,8 @@
+-- 팀당 최소 소속 인원 제한
+-- 주최측에 본회 소속으로 등록하려면 팀에 소속 회원이 있어야 하므로,
+-- 외부 선수만으로 이루어진 팀은 신청을 막는다.
+--
+-- 기본값 0(제한 없음)이라 기존 대회는 동작이 바뀌지 않는다.
+
+-- AlterTable
+ALTER TABLE "Tournament" ADD COLUMN     "minClubMembersPerTeam" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -496,11 +496,7 @@ model EntryPlayer {
   phoneNumber  String                                    // 민감정보
   tshirtSize   String?                                   // 민감정보
   // Tournament.memberLabel 기준 회원 여부. 추가금 미사용 대회에서는 의미 없다.
-  // 참가비 계산에만 쓴다.
   isLocalMember Boolean           @default(true)
-  // 우리 클럽 소속 여부. 금액과 무관하며 명단 파악·주최측 제출용이다.
-  // isLocalMember와 독립이다 (클럽 사람이어도 영등포구 회원이 아닐 수 있다).
-  isClubMember  Boolean           @default(true)
   order        Int                @default(0)
 
   entry        TournamentEntry    @relation(fields: [entryId], references: [id], onDelete: Cascade)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -408,7 +408,10 @@ model Tournament {
   bankAccount     String?                                  // 입금 계좌 안내
   // 비회원 추가금. surcharge가 0이면 기능 자체를 쓰지 않는 대회다.
   memberLabel        String?                               // 회원 기준 라벨 (예: 영등포구 회원)
-  nonMemberSurcharge Int     @default(0)                   // 비회원 1인당 추가금 (원)
+  nonMemberSurcharge Int     @default(0)                   // 외부 선수 1인당 추가금 (원)
+  // 팀당 최소 소속 인원. 주최측에 본회 소속으로 등록하려면 팀에 소속 회원이
+  // 있어야 하므로, 외부 선수만으로 이루어진 팀은 신청을 막는다. 0이면 제한 없음.
+  minClubMembersPerTeam Int  @default(0)
   // 연령·급수는 금액과 무관한 단순 선택지라 문자열 배열로 둔다.
   // 종목(TournamentEventType)만 금액을 가지므로 별도 테이블이다.
   ageGroups       String[]                                 // 20대, 30대 ...

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -496,7 +496,11 @@ model EntryPlayer {
   phoneNumber  String                                    // 민감정보
   tshirtSize   String?                                   // 민감정보
   // Tournament.memberLabel 기준 회원 여부. 추가금 미사용 대회에서는 의미 없다.
+  // 참가비 계산에만 쓴다.
   isLocalMember Boolean           @default(true)
+  // 우리 클럽 소속 여부. 금액과 무관하며 명단 파악·주최측 제출용이다.
+  // isLocalMember와 독립이다 (클럽 사람이어도 영등포구 회원이 아닐 수 있다).
+  isClubMember  Boolean           @default(true)
   order        Int                @default(0)
 
   entry        TournamentEntry    @relation(fields: [entryId], references: [id], onDelete: Cascade)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -406,6 +406,9 @@ model Tournament {
   useTeamName     Boolean           @default(false)        // 팀명 입력 사용 여부
   tshirtSizes     String[]                                 // 빈 배열이면 티셔츠 미사용
   bankAccount     String?                                  // 입금 계좌 안내
+  // 비회원 추가금. surcharge가 0이면 기능 자체를 쓰지 않는 대회다.
+  memberLabel        String?                               // 회원 기준 라벨 (예: 영등포구 회원)
+  nonMemberSurcharge Int     @default(0)                   // 비회원 1인당 추가금 (원)
   // 연령·급수는 금액과 무관한 단순 선택지라 문자열 배열로 둔다.
   // 종목(TournamentEventType)만 금액을 가지므로 별도 테이블이다.
   ageGroups       String[]                                 // 20대, 30대 ...
@@ -492,6 +495,8 @@ model EntryPlayer {
   birthDate    String                                    // 민감정보
   phoneNumber  String                                    // 민감정보
   tshirtSize   String?                                   // 민감정보
+  // Tournament.memberLabel 기준 회원 여부. 추가금 미사용 대회에서는 의미 없다.
+  isLocalMember Boolean           @default(true)
   order        Int                @default(0)
 
   entry        TournamentEntry    @relation(fields: [entryId], references: [id], onDelete: Cascade)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -495,8 +495,10 @@ model EntryPlayer {
   birthDate    String                                    // 민감정보
   phoneNumber  String                                    // 민감정보
   tshirtSize   String?                                   // 민감정보
-  // Tournament.memberLabel 기준 회원 여부. 추가금 미사용 대회에서는 의미 없다.
-  isLocalMember Boolean           @default(true)
+  // Tournament.memberLabel 기준 소속 여부 (예: 당산클럽 소속).
+  // 해제된 선수는 참가 종목마다 nonMemberSurcharge가 붙는다.
+  // 추가금 미사용 대회에서는 의미 없다.
+  isClubMember Boolean            @default(true)
   order        Int                @default(0)
 
   entry        TournamentEntry    @relation(fields: [entryId], references: [id], onDelete: Cascade)

--- a/prisma/schema/tournament.prisma
+++ b/prisma/schema/tournament.prisma
@@ -103,8 +103,10 @@ model EntryPlayer {
   birthDate    String                                    // 민감정보
   phoneNumber  String                                    // 민감정보
   tshirtSize   String?                                   // 민감정보
-  // Tournament.memberLabel 기준 회원 여부. 추가금 미사용 대회에서는 의미 없다.
-  isLocalMember Boolean           @default(true)
+  // Tournament.memberLabel 기준 소속 여부 (예: 당산클럽 소속).
+  // 해제된 선수는 참가 종목마다 nonMemberSurcharge가 붙는다.
+  // 추가금 미사용 대회에서는 의미 없다.
+  isClubMember Boolean            @default(true)
   order        Int                @default(0)
 
   entry        TournamentEntry    @relation(fields: [entryId], references: [id], onDelete: Cascade)

--- a/prisma/schema/tournament.prisma
+++ b/prisma/schema/tournament.prisma
@@ -104,7 +104,11 @@ model EntryPlayer {
   phoneNumber  String                                    // 민감정보
   tshirtSize   String?                                   // 민감정보
   // Tournament.memberLabel 기준 회원 여부. 추가금 미사용 대회에서는 의미 없다.
+  // 참가비 계산에만 쓴다.
   isLocalMember Boolean           @default(true)
+  // 우리 클럽 소속 여부. 금액과 무관하며 명단 파악·주최측 제출용이다.
+  // isLocalMember와 독립이다 (클럽 사람이어도 영등포구 회원이 아닐 수 있다).
+  isClubMember  Boolean           @default(true)
   order        Int                @default(0)
 
   entry        TournamentEntry    @relation(fields: [entryId], references: [id], onDelete: Cascade)

--- a/prisma/schema/tournament.prisma
+++ b/prisma/schema/tournament.prisma
@@ -104,11 +104,7 @@ model EntryPlayer {
   phoneNumber  String                                    // 민감정보
   tshirtSize   String?                                   // 민감정보
   // Tournament.memberLabel 기준 회원 여부. 추가금 미사용 대회에서는 의미 없다.
-  // 참가비 계산에만 쓴다.
   isLocalMember Boolean           @default(true)
-  // 우리 클럽 소속 여부. 금액과 무관하며 명단 파악·주최측 제출용이다.
-  // isLocalMember와 독립이다 (클럽 사람이어도 영등포구 회원이 아닐 수 있다).
-  isClubMember  Boolean           @default(true)
   order        Int                @default(0)
 
   entry        TournamentEntry    @relation(fields: [entryId], references: [id], onDelete: Cascade)

--- a/prisma/schema/tournament.prisma
+++ b/prisma/schema/tournament.prisma
@@ -14,6 +14,9 @@ model Tournament {
   useTeamName     Boolean           @default(false)        // 팀명 입력 사용 여부
   tshirtSizes     String[]                                 // 빈 배열이면 티셔츠 미사용
   bankAccount     String?                                  // 입금 계좌 안내
+  // 비회원 추가금. surcharge가 0이면 기능 자체를 쓰지 않는 대회다.
+  memberLabel        String?                               // 회원 기준 라벨 (예: 영등포구 회원)
+  nonMemberSurcharge Int     @default(0)                   // 비회원 1인당 추가금 (원)
   // 연령·급수는 금액과 무관한 단순 선택지라 문자열 배열로 둔다.
   // 종목(TournamentEventType)만 금액을 가지므로 별도 테이블이다.
   ageGroups       String[]                                 // 20대, 30대 ...
@@ -100,6 +103,8 @@ model EntryPlayer {
   birthDate    String                                    // 민감정보
   phoneNumber  String                                    // 민감정보
   tshirtSize   String?                                   // 민감정보
+  // Tournament.memberLabel 기준 회원 여부. 추가금 미사용 대회에서는 의미 없다.
+  isLocalMember Boolean           @default(true)
   order        Int                @default(0)
 
   entry        TournamentEntry    @relation(fields: [entryId], references: [id], onDelete: Cascade)

--- a/prisma/schema/tournament.prisma
+++ b/prisma/schema/tournament.prisma
@@ -16,7 +16,10 @@ model Tournament {
   bankAccount     String?                                  // 입금 계좌 안내
   // 비회원 추가금. surcharge가 0이면 기능 자체를 쓰지 않는 대회다.
   memberLabel        String?                               // 회원 기준 라벨 (예: 영등포구 회원)
-  nonMemberSurcharge Int     @default(0)                   // 비회원 1인당 추가금 (원)
+  nonMemberSurcharge Int     @default(0)                   // 외부 선수 1인당 추가금 (원)
+  // 팀당 최소 소속 인원. 주최측에 본회 소속으로 등록하려면 팀에 소속 회원이
+  // 있어야 하므로, 외부 선수만으로 이루어진 팀은 신청을 막는다. 0이면 제한 없음.
+  minClubMembersPerTeam Int  @default(0)
   // 연령·급수는 금액과 무관한 단순 선택지라 문자열 배열로 둔다.
   // 종목(TournamentEventType)만 금액을 가지므로 별도 테이블이다.
   ageGroups       String[]                                 // 20대, 30대 ...

--- a/src/__tests__/components/tournament/EntrySummary.dom.test.tsx
+++ b/src/__tests__/components/tournament/EntrySummary.dom.test.tsx
@@ -40,6 +40,7 @@ function renderEntrySummary(options?: {
             eventTypes={[] as unknown as TournamentEventType[]}
             useTeamName={false}
             bankAccount={null}
+            nonMemberSurcharge={0}
           />
           <button type="submit">제출</button>
         </form>

--- a/src/__tests__/components/tournament/EntryTable.dom.test.tsx
+++ b/src/__tests__/components/tournament/EntryTable.dom.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import EntryTable from '@/components/organisms/tournament/admin/EntryTable';
+
+import type { EntryForAdmin } from '@/types/tournament.types';
+
+/**
+ * EntryForAdmin은 Prisma 전체 타입이라 필드가 많다.
+ * 화면이 실제로 읽는 값만 채우고 나머지는 단언으로 넘긴다.
+ */
+function makeEntry(
+  overrides: {
+    id?: string;
+    memberName?: string;
+    players?: Array<{ name: string; isClubMember: boolean }>;
+  } = {}
+): EntryForAdmin {
+  const players = (
+    overrides.players ?? [
+      { name: '홍길동', isClubMember: true },
+      { name: '김철수', isClubMember: true },
+    ]
+  ).map((player, index) => ({
+    id: `p-${index}`,
+    name: player.name,
+    isClubMember: player.isClubMember,
+  }));
+
+  return {
+    id: overrides.id ?? 'e1',
+    depositorName: '홍길동',
+    teamName: null,
+    paymentStatus: 'PENDING',
+    totalFee: 60000,
+    clubMember: { id: 1, name: overrides.memberName ?? '홍길동' },
+    players,
+    entryEvents: [
+      {
+        id: 'ev-1',
+        status: 'ACTIVE',
+        ageGroup: '30대',
+        level: 'A조',
+        eventType: { name: '남자복식' },
+      },
+    ],
+  } as unknown as EntryForAdmin;
+}
+
+function renderTable(entries: EntryForAdmin[]) {
+  return render(
+    <EntryTable entries={entries} onChangePaymentStatus={jest.fn()} />
+  );
+}
+
+describe('EntryTable - 외부 선수 표시', () => {
+  it('전원이 클럽 소속이면 외부 표시를 붙이지 않는다', () => {
+    renderTable([makeEntry()]);
+
+    expect(screen.queryByText(/외부/)).toBeNull();
+  });
+
+  it('외부 선수가 있으면 인원수를 보여준다', () => {
+    renderTable([
+      makeEntry({
+        players: [
+          { name: '홍길동', isClubMember: true },
+          { name: '김철수', isClubMember: false },
+        ],
+      }),
+    ]);
+
+    // 모바일 카드와 PC 표 양쪽에 나오므로 2개다.
+    expect(screen.getAllByText('외부 1명')).toHaveLength(2);
+  });
+
+  it('외부 선수가 2명이면 2명으로 센다', () => {
+    renderTable([
+      makeEntry({
+        players: [
+          { name: '홍길동', isClubMember: false },
+          { name: '김철수', isClubMember: false },
+        ],
+      }),
+    ]);
+
+    expect(screen.getAllByText('외부 2명')).toHaveLength(2);
+  });
+
+  it('외부 선수의 이름을 함께 보여준다', () => {
+    renderTable([
+      makeEntry({
+        players: [
+          { name: '홍길동', isClubMember: true },
+          { name: '김철수', isClubMember: false },
+        ],
+      }),
+    ]);
+
+    // 누가 외부인지 알아야 주최측 제출 명단을 만들 수 있다.
+    expect(screen.getAllByText('김철수').length).toBeGreaterThan(0);
+  });
+
+  it('신청서마다 따로 계산한다', () => {
+    renderTable([
+      makeEntry({ id: 'e1', memberName: '홍길동' }),
+      makeEntry({
+        id: 'e2',
+        memberName: '이영희',
+        players: [
+          { name: '이영희', isClubMember: true },
+          { name: '박민수', isClubMember: false },
+        ],
+      }),
+    ]);
+
+    // 두 번째 신청서에만 외부가 있다.
+    expect(screen.getAllByText('외부 1명')).toHaveLength(2);
+  });
+});

--- a/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
+++ b/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
@@ -23,6 +23,7 @@ const 남자복식: EventGroup = {
           phoneNumber: '010-1111-1111',
           tshirtSize: 'L',
           isLocalMember: true,
+          isClubMember: true,
         },
         {
           name: '박영희',
@@ -30,6 +31,7 @@ const 남자복식: EventGroup = {
           phoneNumber: '010-2222-2222',
           tshirtSize: null,
           isLocalMember: false,
+          isClubMember: false,
         },
       ],
     },
@@ -45,6 +47,7 @@ const 남자복식: EventGroup = {
           phoneNumber: '010-3333-3333',
           tshirtSize: 'M',
           isLocalMember: true,
+          isClubMember: true,
         },
         {
           name: '정다은',
@@ -52,6 +55,7 @@ const 남자복식: EventGroup = {
           phoneNumber: '010-4444-4444',
           tshirtSize: 'S',
           isLocalMember: true,
+          isClubMember: true,
         },
       ],
     },
@@ -122,6 +126,7 @@ describe('EventGroupList', () => {
               phoneNumber: '010-1111-1111',
               tshirtSize: 'L',
               isLocalMember: true,
+              isClubMember: true,
             },
           ],
         },
@@ -144,10 +149,17 @@ describe('EventGroupList', () => {
 });
 
 describe('EventGroupList - 회원 여부 배지', () => {
-  it('memberLabel이 없으면 회원 여부를 표시하지 않는다', () => {
+  it('memberLabel이 없으면 추가금 배지를 표시하지 않는다', () => {
     render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
 
     expect(screen.queryByText(/아님/)).toBeNull();
+  });
+
+  it('외부 선수에게는 memberLabel과 무관하게 외부 표시를 붙인다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    // 팀 요약(외부 1명)과 별개로 선수 줄에도 '외부'가 붙는다.
+    expect(screen.getByText('외부')).toBeTruthy();
   });
 
   it('비회원 선수에게만 배지를 붙인다', () => {
@@ -162,5 +174,46 @@ describe('EventGroupList - 회원 여부 배지', () => {
     // 4명 중 박영희 1명만 비회원이다.
     const badges = screen.getAllByText('영등포구 회원 아님');
     expect(badges).toHaveLength(1);
+  });
+});
+
+describe('EventGroupList - 팀별 외부 인원 요약', () => {
+  it('외부 인원이 있는 팀의 제목 줄에 인원수를 요약한다', () => {
+    // 추가금과 무관하므로 memberLabel 없이도 표시되어야 한다.
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    // 첫 팀(홍길동·박영희)에만 외부 1명이 있다.
+    const summaries = screen.getAllByText('외부 1명');
+    expect(summaries).toHaveLength(1);
+  });
+
+  it('전원이 클럽 회원인 팀에는 요약을 붙이지 않는다', () => {
+    const 전원내부: EventGroup = {
+      ...남자복식,
+      teams: [남자복식.teams[1]],
+    };
+
+    render(<EventGroupList groups={[전원내부]} useTeamName={false} />);
+
+    expect(screen.queryByText(/외부 \d+명/)).toBeNull();
+  });
+
+  it('한 팀에 외부 인원이 2명이면 2명으로 센다', () => {
+    const 전원외부: EventGroup = {
+      ...남자복식,
+      teams: [
+        {
+          ...남자복식.teams[0],
+          players: 남자복식.teams[0].players.map((player) => ({
+            ...player,
+            isClubMember: false,
+          })),
+        },
+      ],
+    };
+
+    render(<EventGroupList groups={[전원외부]} useTeamName={false} />);
+
+    expect(screen.getByText('외부 2명')).toBeTruthy();
   });
 });

--- a/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
+++ b/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
@@ -22,14 +22,14 @@ const 남자복식: EventGroup = {
           birthDate: '1990-03-15',
           phoneNumber: '010-1111-1111',
           tshirtSize: 'L',
-          isLocalMember: true,
+          isClubMember: true,
         },
         {
           name: '박영희',
           birthDate: '1992-07-01',
           phoneNumber: '010-2222-2222',
           tshirtSize: null,
-          isLocalMember: false,
+          isClubMember: false,
         },
       ],
     },
@@ -44,14 +44,14 @@ const 남자복식: EventGroup = {
           birthDate: '1988-05-05',
           phoneNumber: '010-3333-3333',
           tshirtSize: 'M',
-          isLocalMember: true,
+          isClubMember: true,
         },
         {
           name: '정다은',
           birthDate: '1995-12-25',
           phoneNumber: '010-4444-4444',
           tshirtSize: 'S',
-          isLocalMember: true,
+          isClubMember: true,
         },
       ],
     },
@@ -121,7 +121,7 @@ describe('EventGroupList', () => {
               birthDate: '1990-03-15',
               phoneNumber: '010-1111-1111',
               tshirtSize: 'L',
-              isLocalMember: true,
+              isClubMember: true,
             },
           ],
         },
@@ -143,14 +143,14 @@ describe('EventGroupList', () => {
   });
 });
 
-describe('EventGroupList - 회원 여부 배지', () => {
-  it('memberLabel이 없으면 회원 여부를 표시하지 않는다', () => {
+describe('EventGroupList - 소속 여부 배지', () => {
+  it('memberLabel이 없으면 소속 여부를 표시하지 않는다', () => {
     render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
 
     expect(screen.queryByText(/아님/)).toBeNull();
   });
 
-  it('비회원 선수에게만 배지를 붙인다', () => {
+  it('외부 선수에게만 배지를 붙인다', () => {
     render(
       <EventGroupList
         groups={[남자복식]}

--- a/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
+++ b/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
@@ -23,7 +23,6 @@ const 남자복식: EventGroup = {
           phoneNumber: '010-1111-1111',
           tshirtSize: 'L',
           isLocalMember: true,
-          isClubMember: true,
         },
         {
           name: '박영희',
@@ -31,7 +30,6 @@ const 남자복식: EventGroup = {
           phoneNumber: '010-2222-2222',
           tshirtSize: null,
           isLocalMember: false,
-          isClubMember: false,
         },
       ],
     },
@@ -47,7 +45,6 @@ const 남자복식: EventGroup = {
           phoneNumber: '010-3333-3333',
           tshirtSize: 'M',
           isLocalMember: true,
-          isClubMember: true,
         },
         {
           name: '정다은',
@@ -55,7 +52,6 @@ const 남자복식: EventGroup = {
           phoneNumber: '010-4444-4444',
           tshirtSize: 'S',
           isLocalMember: true,
-          isClubMember: true,
         },
       ],
     },
@@ -126,7 +122,6 @@ describe('EventGroupList', () => {
               phoneNumber: '010-1111-1111',
               tshirtSize: 'L',
               isLocalMember: true,
-              isClubMember: true,
             },
           ],
         },
@@ -149,17 +144,10 @@ describe('EventGroupList', () => {
 });
 
 describe('EventGroupList - 회원 여부 배지', () => {
-  it('memberLabel이 없으면 추가금 배지를 표시하지 않는다', () => {
+  it('memberLabel이 없으면 회원 여부를 표시하지 않는다', () => {
     render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
 
     expect(screen.queryByText(/아님/)).toBeNull();
-  });
-
-  it('외부 선수에게는 memberLabel과 무관하게 외부 표시를 붙인다', () => {
-    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
-
-    // 팀 요약(외부 1명)과 별개로 선수 줄에도 '외부'가 붙는다.
-    expect(screen.getByText('외부')).toBeTruthy();
   });
 
   it('비회원 선수에게만 배지를 붙인다', () => {
@@ -174,46 +162,5 @@ describe('EventGroupList - 회원 여부 배지', () => {
     // 4명 중 박영희 1명만 비회원이다.
     const badges = screen.getAllByText('영등포구 회원 아님');
     expect(badges).toHaveLength(1);
-  });
-});
-
-describe('EventGroupList - 팀별 외부 인원 요약', () => {
-  it('외부 인원이 있는 팀의 제목 줄에 인원수를 요약한다', () => {
-    // 추가금과 무관하므로 memberLabel 없이도 표시되어야 한다.
-    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
-
-    // 첫 팀(홍길동·박영희)에만 외부 1명이 있다.
-    const summaries = screen.getAllByText('외부 1명');
-    expect(summaries).toHaveLength(1);
-  });
-
-  it('전원이 클럽 회원인 팀에는 요약을 붙이지 않는다', () => {
-    const 전원내부: EventGroup = {
-      ...남자복식,
-      teams: [남자복식.teams[1]],
-    };
-
-    render(<EventGroupList groups={[전원내부]} useTeamName={false} />);
-
-    expect(screen.queryByText(/외부 \d+명/)).toBeNull();
-  });
-
-  it('한 팀에 외부 인원이 2명이면 2명으로 센다', () => {
-    const 전원외부: EventGroup = {
-      ...남자복식,
-      teams: [
-        {
-          ...남자복식.teams[0],
-          players: 남자복식.teams[0].players.map((player) => ({
-            ...player,
-            isClubMember: false,
-          })),
-        },
-      ],
-    };
-
-    render(<EventGroupList groups={[전원외부]} useTeamName={false} />);
-
-    expect(screen.getByText('외부 2명')).toBeTruthy();
   });
 });

--- a/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
+++ b/src/__tests__/components/tournament/EventGroupList.dom.test.tsx
@@ -22,12 +22,14 @@ const 남자복식: EventGroup = {
           birthDate: '1990-03-15',
           phoneNumber: '010-1111-1111',
           tshirtSize: 'L',
+          isLocalMember: true,
         },
         {
           name: '박영희',
           birthDate: '1992-07-01',
           phoneNumber: '010-2222-2222',
           tshirtSize: null,
+          isLocalMember: false,
         },
       ],
     },
@@ -42,12 +44,14 @@ const 남자복식: EventGroup = {
           birthDate: '1988-05-05',
           phoneNumber: '010-3333-3333',
           tshirtSize: 'M',
+          isLocalMember: true,
         },
         {
           name: '정다은',
           birthDate: '1995-12-25',
           phoneNumber: '010-4444-4444',
           tshirtSize: 'S',
+          isLocalMember: true,
         },
       ],
     },
@@ -117,6 +121,7 @@ describe('EventGroupList', () => {
               birthDate: '1990-03-15',
               phoneNumber: '010-1111-1111',
               tshirtSize: 'L',
+              isLocalMember: true,
             },
           ],
         },
@@ -135,5 +140,27 @@ describe('EventGroupList', () => {
     render(<EventGroupList groups={[]} useTeamName={false} />);
 
     expect(screen.getByText('신청 내역이 없습니다.')).toBeTruthy();
+  });
+});
+
+describe('EventGroupList - 회원 여부 배지', () => {
+  it('memberLabel이 없으면 회원 여부를 표시하지 않는다', () => {
+    render(<EventGroupList groups={[남자복식]} useTeamName={false} />);
+
+    expect(screen.queryByText(/아님/)).toBeNull();
+  });
+
+  it('비회원 선수에게만 배지를 붙인다', () => {
+    render(
+      <EventGroupList
+        groups={[남자복식]}
+        useTeamName={false}
+        memberLabel="영등포구 회원"
+      />
+    );
+
+    // 4명 중 박영희 1명만 비회원이다.
+    const badges = screen.getAllByText('영등포구 회원 아님');
+    expect(badges).toHaveLength(1);
   });
 });

--- a/src/__tests__/components/tournament/EventListField.dom.test.tsx
+++ b/src/__tests__/components/tournament/EventListField.dom.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import {
+  createEmptyPlayer,
+  type EntryFormValues,
+} from '@/components/organisms/tournament/entry/entryFormTypes';
+import EventListField from '@/components/organisms/tournament/entry/EventListField';
+
+import type { TournamentEventType } from '@prisma/client';
+
+const EVENT_TYPES = [
+  {
+    id: 'et-double',
+    name: '남자복식',
+    playerCount: 2,
+    fee: 60000,
+    isActive: true,
+    order: 0,
+    tournamentId: 't1',
+  },
+] as unknown as TournamentEventType[];
+
+/** p1/p2의 소속 여부를 지정하고, 두 선수를 한 종목에 배정한 폼을 그린다. */
+function renderEventListField(options: {
+  memberFlags: boolean[];
+  minClubMembersPerTeam?: number;
+  memberLabel?: string | null;
+}) {
+  const players = options.memberFlags.map((isClubMember, index) => ({
+    ...createEmptyPlayer(index),
+    key: `p${index + 1}`,
+    name: `선수${index + 1}`,
+    isClubMember,
+  }));
+
+  function Wrapper() {
+    const methods = useForm<EntryFormValues>({
+      defaultValues: {
+        depositorName: '',
+        teamName: '',
+        players,
+        events: [
+          {
+            eventTypeId: 'et-double',
+            ageGroup: '30대',
+            level: 'A조',
+            playerKeys: players.map((p) => p.key),
+          },
+        ],
+        privacyAgreed: false,
+      },
+    });
+
+    return (
+      <FormProvider {...methods}>
+        <EventListField
+          eventTypes={EVENT_TYPES}
+          ageGroups={['30대']}
+          levels={['A조']}
+          memberLabel={options.memberLabel ?? '당산클럽 소속'}
+          minClubMembersPerTeam={options.minClubMembersPerTeam ?? 1}
+        />
+      </FormProvider>
+    );
+  }
+
+  return render(<Wrapper />);
+}
+
+describe('EventListField - 팀당 최소 소속 인원 안내', () => {
+  it('소속 회원이 있으면 경고를 띄우지 않는다', () => {
+    renderEventListField({ memberFlags: [true, false] });
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('전원 외부면 신청할 수 없다고 알려준다', () => {
+    renderEventListField({ memberFlags: [false, false] });
+
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('당산클럽 소속');
+    expect(alert.textContent).toContain('1명');
+  });
+
+  it('제한이 0이면 전원 외부여도 경고하지 않는다', () => {
+    renderEventListField({
+      memberFlags: [false, false],
+      minClubMembersPerTeam: 0,
+    });
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('대회가 정한 라벨을 그대로 보여준다', () => {
+    renderEventListField({
+      memberFlags: [false, false],
+      memberLabel: '영등포구 회원',
+    });
+
+    expect(screen.getByRole('alert').textContent).toContain('영등포구 회원');
+  });
+});

--- a/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
+++ b/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
@@ -57,6 +57,14 @@ function renderPlayerListField(options?: {
   return render(<Wrapper />);
 }
 
+/** 라벨 문구로 n번째 선수의 체크박스를 찾는다. 체크박스가 여러 개라 필요하다. */
+function getCheckboxByLabel(label: string, index = 0): HTMLInputElement {
+  const labels = screen.getAllByText(label);
+  return labels[index]
+    .closest('label')
+    ?.querySelector('input') as HTMLInputElement;
+}
+
 /** n번째 선수의 생년월일 입력창을 가져온다. */
 function getBirthDateInput(index = 0): HTMLInputElement {
   return screen.getAllByPlaceholderText('예: 19900315')[
@@ -345,8 +353,7 @@ describe('PlayerListField - 비회원 추가금', () => {
   it('기본값은 회원(체크됨)이다', () => {
     renderPlayerListField(SURCHARGE);
 
-    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
-    expect(checkbox.checked).toBe(true);
+    expect(getCheckboxByLabel('영등포구 회원').checked).toBe(true);
   });
 
   it('체크를 해제하면 isLocalMember=false로 제출한다', async () => {
@@ -364,7 +371,7 @@ describe('PlayerListField - 비회원 추가금', () => {
       onSubmit,
     });
 
-    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(getCheckboxByLabel('영등포구 회원'));
     fireEvent.click(screen.getByText('제출'));
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
@@ -379,13 +386,61 @@ describe('PlayerListField - 비회원 추가금', () => {
       players: [{ isLocalMember: true }, { isLocalMember: true }],
     });
 
-    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
-    expect(checkboxes).toHaveLength(2);
+    const first = getCheckboxByLabel('영등포구 회원', 0);
+    const second = getCheckboxByLabel('영등포구 회원', 1);
 
-    fireEvent.click(checkboxes[1]);
+    fireEvent.click(second);
 
     // 두 번째만 해제되고 첫 번째는 유지되어야 한다.
-    expect(checkboxes[0].checked).toBe(true);
-    expect(checkboxes[1].checked).toBe(false);
+    expect(first.checked).toBe(true);
+    expect(second.checked).toBe(false);
+  });
+});
+
+describe('PlayerListField - 클럽 소속', () => {
+  it('추가금과 무관하게 항상 클럽 회원 여부를 묻는다', () => {
+    renderPlayerListField();
+
+    expect(screen.getByText('우리 클럽 회원')).toBeTruthy();
+  });
+
+  it('기본값은 클럽 회원(체크됨)이다', () => {
+    renderPlayerListField();
+
+    expect(getCheckboxByLabel('우리 클럽 회원').checked).toBe(true);
+  });
+
+  it('체크를 해제하면 isClubMember=false로 제출한다', async () => {
+    const onSubmit = jest.fn();
+    renderPlayerListField({
+      players: [
+        {
+          name: '김철수',
+          gender: '남',
+          birthDate: '1988-05-05',
+          phoneNumber: '010-3333-4444',
+        },
+      ],
+      onSubmit,
+    });
+
+    fireEvent.click(getCheckboxByLabel('우리 클럽 회원'));
+    fireEvent.click(screen.getByText('제출'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+
+    const submitted = onSubmit.mock.calls[0][0] as EntryFormValues;
+    expect(submitted.players[0].isClubMember).toBe(false);
+  });
+
+  it('추가금을 쓰는 대회에서는 체크박스가 두 개다', () => {
+    renderPlayerListField({
+      memberLabel: '영등포구 회원',
+      nonMemberSurcharge: 10000,
+    });
+
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+    expect(screen.getByText('우리 클럽 회원')).toBeTruthy();
+    expect(screen.getByText('영등포구 회원')).toBeTruthy();
   });
 });

--- a/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
+++ b/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
@@ -17,6 +17,8 @@ import PlayerListField from '@/components/organisms/tournament/entry/PlayerListF
 function renderPlayerListField(options?: {
   players?: Partial<EntryFormValues['players'][number]>[];
   onSubmit?: (values: EntryFormValues) => void;
+  memberLabel?: string | null;
+  nonMemberSurcharge?: number;
 }) {
   const players = (options?.players ?? [{}]).map((override, index) => ({
     ...createEmptyPlayer(index),
@@ -41,7 +43,11 @@ function renderPlayerListField(options?: {
             options?.onSubmit?.(values)
           )}
         >
-          <PlayerListField tshirtSizes={[]} />
+          <PlayerListField
+            tshirtSizes={[]}
+            memberLabel={options?.memberLabel ?? null}
+            nonMemberSurcharge={options?.nonMemberSurcharge ?? 0}
+          />
           <button type="submit">제출</button>
         </form>
       </FormProvider>
@@ -306,5 +312,80 @@ describe('PlayerListField - 선수가 여러 명일 때', () => {
 
     const messages = await screen.findAllByText('올바른 생년월일이 아닙니다.');
     expect(messages).toHaveLength(1);
+  });
+});
+
+describe('PlayerListField - 비회원 추가금', () => {
+  const SURCHARGE = { memberLabel: '영등포구 회원', nonMemberSurcharge: 10000 };
+
+  it('추가금을 쓰지 않는 대회면 회원 여부를 묻지 않는다', () => {
+    renderPlayerListField();
+
+    expect(screen.queryByText('영등포구 회원')).toBeNull();
+  });
+
+  it('라벨만 있고 추가금이 0이면 체크박스를 숨긴다', () => {
+    renderPlayerListField({
+      memberLabel: '영등포구 회원',
+      nonMemberSurcharge: 0,
+    });
+
+    expect(screen.queryByText('영등포구 회원')).toBeNull();
+  });
+
+  it('추가금을 쓰면 대회가 정한 라벨과 금액을 보여준다', () => {
+    renderPlayerListField(SURCHARGE);
+
+    expect(screen.getByText('영등포구 회원')).toBeTruthy();
+    expect(
+      screen.getByText(/해제하면 참가 종목마다 10,000원이 추가됩니다./)
+    ).toBeTruthy();
+  });
+
+  it('기본값은 회원(체크됨)이다', () => {
+    renderPlayerListField(SURCHARGE);
+
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('체크를 해제하면 isLocalMember=false로 제출한다', async () => {
+    const onSubmit = jest.fn();
+    renderPlayerListField({
+      ...SURCHARGE,
+      players: [
+        {
+          name: '김철수',
+          gender: '남',
+          birthDate: '1988-05-05',
+          phoneNumber: '010-3333-4444',
+        },
+      ],
+      onSubmit,
+    });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByText('제출'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+
+    const submitted = onSubmit.mock.calls[0][0] as EntryFormValues;
+    expect(submitted.players[0].isLocalMember).toBe(false);
+  });
+
+  it('선수마다 회원 여부를 따로 관리한다', () => {
+    renderPlayerListField({
+      ...SURCHARGE,
+      players: [{ isLocalMember: true }, { isLocalMember: true }],
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes).toHaveLength(2);
+
+    fireEvent.click(checkboxes[1]);
+
+    // 두 번째만 해제되고 첫 번째는 유지되어야 한다.
+    expect(checkboxes[0].checked).toBe(true);
+    expect(checkboxes[1].checked).toBe(false);
   });
 });

--- a/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
+++ b/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
@@ -315,10 +315,10 @@ describe('PlayerListField - 선수가 여러 명일 때', () => {
   });
 });
 
-describe('PlayerListField - 비회원 추가금', () => {
+describe('PlayerListField - 외부 선수 추가금', () => {
   const SURCHARGE = { memberLabel: '영등포구 회원', nonMemberSurcharge: 10000 };
 
-  it('추가금을 쓰지 않는 대회면 회원 여부를 묻지 않는다', () => {
+  it('추가금을 쓰지 않는 대회면 소속 여부를 묻지 않는다', () => {
     renderPlayerListField();
 
     expect(screen.queryByText('영등포구 회원')).toBeNull();
@@ -342,14 +342,14 @@ describe('PlayerListField - 비회원 추가금', () => {
     ).toBeTruthy();
   });
 
-  it('기본값은 회원(체크됨)이다', () => {
+  it('기본값은 소속(체크됨)이다', () => {
     renderPlayerListField(SURCHARGE);
 
     const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
     expect(checkbox.checked).toBe(true);
   });
 
-  it('체크를 해제하면 isLocalMember=false로 제출한다', async () => {
+  it('체크를 해제하면 isClubMember=false로 제출한다', async () => {
     const onSubmit = jest.fn();
     renderPlayerListField({
       ...SURCHARGE,
@@ -370,13 +370,13 @@ describe('PlayerListField - 비회원 추가금', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
 
     const submitted = onSubmit.mock.calls[0][0] as EntryFormValues;
-    expect(submitted.players[0].isLocalMember).toBe(false);
+    expect(submitted.players[0].isClubMember).toBe(false);
   });
 
-  it('선수마다 회원 여부를 따로 관리한다', () => {
+  it('선수마다 소속 여부를 따로 관리한다', () => {
     renderPlayerListField({
       ...SURCHARGE,
-      players: [{ isLocalMember: true }, { isLocalMember: true }],
+      players: [{ isClubMember: true }, { isClubMember: true }],
     });
 
     const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];

--- a/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
+++ b/src/__tests__/components/tournament/PlayerListField.dom.test.tsx
@@ -57,14 +57,6 @@ function renderPlayerListField(options?: {
   return render(<Wrapper />);
 }
 
-/** 라벨 문구로 n번째 선수의 체크박스를 찾는다. 체크박스가 여러 개라 필요하다. */
-function getCheckboxByLabel(label: string, index = 0): HTMLInputElement {
-  const labels = screen.getAllByText(label);
-  return labels[index]
-    .closest('label')
-    ?.querySelector('input') as HTMLInputElement;
-}
-
 /** n번째 선수의 생년월일 입력창을 가져온다. */
 function getBirthDateInput(index = 0): HTMLInputElement {
   return screen.getAllByPlaceholderText('예: 19900315')[
@@ -353,7 +345,8 @@ describe('PlayerListField - 비회원 추가금', () => {
   it('기본값은 회원(체크됨)이다', () => {
     renderPlayerListField(SURCHARGE);
 
-    expect(getCheckboxByLabel('영등포구 회원').checked).toBe(true);
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
   });
 
   it('체크를 해제하면 isLocalMember=false로 제출한다', async () => {
@@ -371,7 +364,7 @@ describe('PlayerListField - 비회원 추가금', () => {
       onSubmit,
     });
 
-    fireEvent.click(getCheckboxByLabel('영등포구 회원'));
+    fireEvent.click(screen.getByRole('checkbox'));
     fireEvent.click(screen.getByText('제출'));
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
@@ -386,61 +379,13 @@ describe('PlayerListField - 비회원 추가금', () => {
       players: [{ isLocalMember: true }, { isLocalMember: true }],
     });
 
-    const first = getCheckboxByLabel('영등포구 회원', 0);
-    const second = getCheckboxByLabel('영등포구 회원', 1);
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes).toHaveLength(2);
 
-    fireEvent.click(second);
+    fireEvent.click(checkboxes[1]);
 
     // 두 번째만 해제되고 첫 번째는 유지되어야 한다.
-    expect(first.checked).toBe(true);
-    expect(second.checked).toBe(false);
-  });
-});
-
-describe('PlayerListField - 클럽 소속', () => {
-  it('추가금과 무관하게 항상 클럽 회원 여부를 묻는다', () => {
-    renderPlayerListField();
-
-    expect(screen.getByText('우리 클럽 회원')).toBeTruthy();
-  });
-
-  it('기본값은 클럽 회원(체크됨)이다', () => {
-    renderPlayerListField();
-
-    expect(getCheckboxByLabel('우리 클럽 회원').checked).toBe(true);
-  });
-
-  it('체크를 해제하면 isClubMember=false로 제출한다', async () => {
-    const onSubmit = jest.fn();
-    renderPlayerListField({
-      players: [
-        {
-          name: '김철수',
-          gender: '남',
-          birthDate: '1988-05-05',
-          phoneNumber: '010-3333-4444',
-        },
-      ],
-      onSubmit,
-    });
-
-    fireEvent.click(getCheckboxByLabel('우리 클럽 회원'));
-    fireEvent.click(screen.getByText('제출'));
-
-    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
-
-    const submitted = onSubmit.mock.calls[0][0] as EntryFormValues;
-    expect(submitted.players[0].isClubMember).toBe(false);
-  });
-
-  it('추가금을 쓰는 대회에서는 체크박스가 두 개다', () => {
-    renderPlayerListField({
-      memberLabel: '영등포구 회원',
-      nonMemberSurcharge: 10000,
-    });
-
-    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
-    expect(screen.getByText('우리 클럽 회원')).toBeTruthy();
-    expect(screen.getByText('영등포구 회원')).toBeTruthy();
+    expect(checkboxes[0].checked).toBe(true);
+    expect(checkboxes[1].checked).toBe(false);
   });
 });

--- a/src/components/organisms/tournament/admin/EntryTable.tsx
+++ b/src/components/organisms/tournament/admin/EntryTable.tsx
@@ -38,6 +38,30 @@ function getActiveEvents(
     }));
 }
 
+/**
+ * 신청서에서 외부 선수만 골라낸다.
+ * 통장 대조 시 추가금이 왜 붙었는지 바로 확인하려면 인원수와 이름이 함께 필요하다.
+ */
+function getExternalPlayers(entry: EntryForAdmin): string[] {
+  return entry.players
+    .filter((player) => !player.isClubMember)
+    .map((player) => player.name);
+}
+
+function ExternalPlayers({ names }: { names: string[] }) {
+  if (names.length === 0) return null;
+
+  // 좁은 화면에서 배지가 찌그러지지 않도록 배지와 이름을 각각 접는다.
+  return (
+    <p className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-amber-700">
+      <span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 font-medium">
+        외부 {names.length}명
+      </span>
+      <span className="min-w-0 break-words">{names.join(' · ')}</span>
+    </p>
+  );
+}
+
 function PaymentStatusSelect({
   entry,
   onChangePaymentStatus,
@@ -90,6 +114,7 @@ function EntryTable({ entries, onChangePaymentStatus }: EntryTableProps) {
                   {entry.teamName && (
                     <p className="text-xs text-gray-400">{entry.teamName}</p>
                   )}
+                  <ExternalPlayers names={getExternalPlayers(entry)} />
                 </div>
                 <PaymentStatusSelect
                   entry={entry}
@@ -149,6 +174,7 @@ function EntryTable({ entries, onChangePaymentStatus }: EntryTableProps) {
                     {entry.teamName && (
                       <p className="text-xs text-gray-400">{entry.teamName}</p>
                     )}
+                    <ExternalPlayers names={getExternalPlayers(entry)} />
                   </td>
                   <td className="py-3">{entry.depositorName}</td>
                   <td className="py-3">

--- a/src/components/organisms/tournament/admin/EventGroupList.tsx
+++ b/src/components/organisms/tournament/admin/EventGroupList.tsx
@@ -5,6 +5,8 @@ import type {
 } from '@/lib/tournament/groupEntriesByEvent';
 
 interface EventGroupListProps {
+  /** 회원 기준 라벨. null이면 회원 여부를 표시하지 않는다 */
+  memberLabel?: string | null;
   groups: EventGroup[];
   useTeamName: boolean;
 }
@@ -18,7 +20,11 @@ function TeamPlayerNames({ team }: { team: GroupedTeam }) {
   );
 }
 
-function EventGroupList({ groups, useTeamName }: EventGroupListProps) {
+function EventGroupList({
+  groups,
+  useTeamName,
+  memberLabel,
+}: EventGroupListProps) {
   if (groups.length === 0) {
     return (
       <p className="rounded-md bg-gray-50 p-6 text-center text-sm text-gray-500">
@@ -77,6 +83,12 @@ function EventGroupList({ groups, useTeamName }: EventGroupListProps) {
                       <span>{player.birthDate || '-'}</span>
                       <span>{player.phoneNumber}</span>
                       <span>티셔츠 {player.tshirtSize ?? '-'}</span>
+                      {/* 추가금 대상자를 임원이 한눈에 보고 입금액을 대조한다. */}
+                      {memberLabel && !player.isLocalMember && (
+                        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-800">
+                          {memberLabel} 아님
+                        </span>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/src/components/organisms/tournament/admin/EventGroupList.tsx
+++ b/src/components/organisms/tournament/admin/EventGroupList.tsx
@@ -20,23 +20,6 @@ function TeamPlayerNames({ team }: { team: GroupedTeam }) {
   );
 }
 
-/**
- * 팀 제목 줄에 외부 인원수를 요약한다.
- * 접어보지 않아도 어느 팀이 추가금 대상인지 바로 보이게 한다.
- */
-function ExternalCountBadge({ team }: { team: GroupedTeam }) {
-  const externalCount = team.players.filter(
-    (player) => !player.isClubMember
-  ).length;
-  if (externalCount === 0) return null;
-
-  return (
-    <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
-      외부 {externalCount}명
-    </span>
-  );
-}
-
 function EventGroupList({
   groups,
   useTeamName,
@@ -80,7 +63,6 @@ function EventGroupList({
                         ({team.teamName})
                       </span>
                     )}
-                    <ExternalCountBadge team={team} />
                   </div>
                   <span
                     className={`shrink-0 rounded-full px-2 py-0.5 text-xs ${PAYMENT_CLASS[team.paymentStatus]}`}
@@ -101,14 +83,9 @@ function EventGroupList({
                       <span>{player.birthDate || '-'}</span>
                       <span>{player.phoneNumber}</span>
                       <span>티셔츠 {player.tshirtSize ?? '-'}</span>
-                      {!player.isClubMember && (
-                        <span className="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-800">
-                          외부
-                        </span>
-                      )}
                       {/* 추가금 대상자를 임원이 한눈에 보고 입금액을 대조한다. */}
                       {memberLabel && !player.isLocalMember && (
-                        <span className="rounded bg-rose-100 px-1.5 py-0.5 text-rose-800">
+                        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-800">
                           {memberLabel} 아님
                         </span>
                       )}

--- a/src/components/organisms/tournament/admin/EventGroupList.tsx
+++ b/src/components/organisms/tournament/admin/EventGroupList.tsx
@@ -20,6 +20,23 @@ function TeamPlayerNames({ team }: { team: GroupedTeam }) {
   );
 }
 
+/**
+ * 팀 제목 줄에 외부 인원수를 요약한다.
+ * 접어보지 않아도 어느 팀이 추가금 대상인지 바로 보이게 한다.
+ */
+function ExternalCountBadge({ team }: { team: GroupedTeam }) {
+  const externalCount = team.players.filter(
+    (player) => !player.isClubMember
+  ).length;
+  if (externalCount === 0) return null;
+
+  return (
+    <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+      외부 {externalCount}명
+    </span>
+  );
+}
+
 function EventGroupList({
   groups,
   useTeamName,
@@ -63,6 +80,7 @@ function EventGroupList({
                         ({team.teamName})
                       </span>
                     )}
+                    <ExternalCountBadge team={team} />
                   </div>
                   <span
                     className={`shrink-0 rounded-full px-2 py-0.5 text-xs ${PAYMENT_CLASS[team.paymentStatus]}`}
@@ -83,9 +101,14 @@ function EventGroupList({
                       <span>{player.birthDate || '-'}</span>
                       <span>{player.phoneNumber}</span>
                       <span>티셔츠 {player.tshirtSize ?? '-'}</span>
+                      {!player.isClubMember && (
+                        <span className="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-800">
+                          외부
+                        </span>
+                      )}
                       {/* 추가금 대상자를 임원이 한눈에 보고 입금액을 대조한다. */}
                       {memberLabel && !player.isLocalMember && (
-                        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-800">
+                        <span className="rounded bg-rose-100 px-1.5 py-0.5 text-rose-800">
                           {memberLabel} 아님
                         </span>
                       )}

--- a/src/components/organisms/tournament/admin/EventGroupList.tsx
+++ b/src/components/organisms/tournament/admin/EventGroupList.tsx
@@ -5,7 +5,7 @@ import type {
 } from '@/lib/tournament/groupEntriesByEvent';
 
 interface EventGroupListProps {
-  /** 회원 기준 라벨. null이면 회원 여부를 표시하지 않는다 */
+  /** 소속 기준 라벨. null이면 소속 여부를 표시하지 않는다 */
   memberLabel?: string | null;
   groups: EventGroup[];
   useTeamName: boolean;
@@ -84,7 +84,7 @@ function EventGroupList({
                       <span>{player.phoneNumber}</span>
                       <span>티셔츠 {player.tshirtSize ?? '-'}</span>
                       {/* 추가금 대상자를 임원이 한눈에 보고 입금액을 대조한다. */}
-                      {memberLabel && !player.isLocalMember && (
+                      {memberLabel && !player.isClubMember && (
                         <span className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-800">
                           {memberLabel} 아님
                         </span>

--- a/src/components/organisms/tournament/admin/TournamentForm.tsx
+++ b/src/components/organisms/tournament/admin/TournamentForm.tsx
@@ -149,6 +149,29 @@ function TournamentForm({
               60,000원 + 외부 선수 1명 → 70,000원)
             </p>
           </FormField>
+
+          {/*
+            주최측에 본회 소속으로 등록하려면 팀에 소속 회원이 있어야 한다.
+            외부 선수만으로 이루어진 팀은 신청 단계에서 막는다.
+          */}
+          <FormField
+            label="팀당 최소 소속 인원"
+            error={methods.formState.errors.minClubMembersPerTeam?.message}
+          >
+            <Input
+              type="number"
+              min={0}
+              max={2}
+              placeholder="0 (제한 없음)"
+              {...methods.register('minClubMembersPerTeam', {
+                valueAsNumber: true,
+              })}
+            />
+            <p className="mt-1 text-xs text-gray-500">
+              한 종목에 이 인원만큼 소속 회원이 없으면 신청할 수 없습니다. 1로
+              두면 외부 선수끼리만 팀을 짤 수 없습니다. 0이면 제한 없음.
+            </p>
+          </FormField>
         </section>
 
         <section className="space-y-4">

--- a/src/components/organisms/tournament/admin/TournamentForm.tsx
+++ b/src/components/organisms/tournament/admin/TournamentForm.tsx
@@ -9,9 +9,9 @@ import { parseTagInput } from '@/lib/tournament/parseTagInput';
 import type { TournamentInput } from '@/types/tournament.types';
 
 import { AGE_GROUP_PRESETS, LEVEL_PRESETS } from './eventOptionPresets';
-import TournamentFileField from './TournamentFileField';
 import EventTypeEditor from './EventTypeEditor';
 import TagListField from './TagListField';
+import TournamentFileField from './TournamentFileField';
 
 interface TournamentFormProps {
   defaultValues: TournamentInput;
@@ -125,13 +125,13 @@ function TournamentForm({
             추가금을 0으로 두면 신청 화면에서 회원 여부를 아예 묻지 않는다.
           */}
           <FormField
-            label="비회원 1인당 추가금"
+            label="외부 선수 1인당 추가금"
             error={methods.formState.errors.memberLabel?.message}
           >
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Input
                 type="text"
-                placeholder="회원 기준 (예: 영등포구 회원)"
+                placeholder="소속 기준 (예: 당산클럽 소속)"
                 {...methods.register('memberLabel')}
               />
               <Input
@@ -145,8 +145,8 @@ function TournamentForm({
               />
             </div>
             <p className="mt-1 text-xs text-gray-500">
-              추가금은 신청 종목마다 비회원 인원수만큼 붙습니다. (예: 팀당
-              60,000원 + 비회원 1명 → 70,000원)
+              추가금은 신청 종목마다 외부 선수 인원수만큼 붙습니다. (예: 팀당
+              60,000원 + 외부 선수 1명 → 70,000원)
             </p>
           </FormField>
         </section>

--- a/src/components/organisms/tournament/admin/TournamentForm.tsx
+++ b/src/components/organisms/tournament/admin/TournamentForm.tsx
@@ -119,6 +119,36 @@ function TournamentForm({
               {...methods.register('bankAccount')}
             />
           </FormField>
+
+          {/*
+            주최측 규칙이 "특정 지역 회원이 아니면 1인당 추가금"인 대회를 위한 설정.
+            추가금을 0으로 두면 신청 화면에서 회원 여부를 아예 묻지 않는다.
+          */}
+          <FormField
+            label="비회원 1인당 추가금"
+            error={methods.formState.errors.memberLabel?.message}
+          >
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Input
+                type="text"
+                placeholder="회원 기준 (예: 영등포구 회원)"
+                {...methods.register('memberLabel')}
+              />
+              <Input
+                type="number"
+                min={0}
+                step={1000}
+                placeholder="추가금 (0이면 미사용)"
+                {...methods.register('nonMemberSurcharge', {
+                  valueAsNumber: true,
+                })}
+              />
+            </div>
+            <p className="mt-1 text-xs text-gray-500">
+              추가금은 신청 종목마다 비회원 인원수만큼 붙습니다. (예: 팀당
+              60,000원 + 비회원 1명 → 70,000원)
+            </p>
+          </FormField>
         </section>
 
         <section className="space-y-4">

--- a/src/components/organisms/tournament/entry/EntrySummary.tsx
+++ b/src/components/organisms/tournament/entry/EntrySummary.tsx
@@ -13,7 +13,7 @@ interface EntrySummaryProps {
   eventTypes: TournamentEventType[];
   useTeamName: boolean;
   bankAccount: string | null;
-  /** 비회원 1인당 추가금. 0이면 추가금 미사용 */
+  /** 외부 선수 1인당 추가금. 0이면 추가금 미사용 */
   nonMemberSurcharge: number;
 }
 
@@ -65,7 +65,7 @@ function EntrySummary({
         </div>
         {totalSurcharge > 0 && (
           <p className="mt-1 text-right text-sm text-gray-600">
-            기본 {formatFee(totalFee - totalSurcharge)} + 비회원 추가금{' '}
+            기본 {formatFee(totalFee - totalSurcharge)} + 외부 선수 추가금{' '}
             {formatFee(totalSurcharge)}
           </p>
         )}

--- a/src/components/organisms/tournament/entry/EntrySummary.tsx
+++ b/src/components/organisms/tournament/entry/EntrySummary.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/atoms/inputs/Input';
 import { FormField } from '@/components/molecules/form/FormField';
 
 import { formatFee } from '@/lib/tournament/display';
+import { calculateEventFee } from '@/lib/tournament/fee';
 
 import type { EntryFormValues } from './entryFormTypes';
 import type { TournamentEventType } from '@prisma/client';
@@ -12,12 +13,15 @@ interface EntrySummaryProps {
   eventTypes: TournamentEventType[];
   useTeamName: boolean;
   bankAccount: string | null;
+  /** 비회원 1인당 추가금. 0이면 추가금 미사용 */
+  nonMemberSurcharge: number;
 }
 
 function EntrySummary({
   eventTypes,
   useTeamName,
   bankAccount,
+  nonMemberSurcharge,
 }: EntrySummaryProps) {
   const {
     register,
@@ -26,13 +30,25 @@ function EntrySummary({
   } = useFormContext<EntryFormValues>();
 
   const events = watch('events') ?? [];
+  const players = watch('players') ?? [];
   const feeById = new Map(
     eventTypes.map((eventType) => [eventType.id, eventType.fee])
   );
 
   // 화면 표시용 금액이다. 실제 청구액은 서버가 다시 계산한다.
-  const totalFee = events.reduce(
-    (sum, event) => sum + (feeById.get(event.eventTypeId) ?? 0),
+  const eventFees = events.map((event) => {
+    const baseFee = feeById.get(event.eventTypeId) ?? 0;
+    const fee = calculateEventFee({
+      baseFee,
+      surcharge: nonMemberSurcharge,
+      playerKeys: event.playerKeys ?? [],
+      players,
+    });
+    return { baseFee, fee, surcharge: fee - baseFee };
+  });
+  const totalFee = eventFees.reduce((sum, item) => sum + item.fee, 0);
+  const totalSurcharge = eventFees.reduce(
+    (sum, item) => sum + item.surcharge,
     0
   );
 
@@ -47,6 +63,12 @@ function EntrySummary({
             {formatFee(totalFee)}
           </span>
         </div>
+        {totalSurcharge > 0 && (
+          <p className="mt-1 text-right text-sm text-gray-600">
+            기본 {formatFee(totalFee - totalSurcharge)} + 비회원 추가금{' '}
+            {formatFee(totalSurcharge)}
+          </p>
+        )}
         {bankAccount && (
           <p className="mt-2 text-sm text-gray-600">입금 계좌: {bankAccount}</p>
         )}

--- a/src/components/organisms/tournament/entry/EventListField.tsx
+++ b/src/components/organisms/tournament/entry/EventListField.tsx
@@ -12,12 +12,18 @@ interface EventListFieldProps {
   eventTypes: TournamentEventType[];
   ageGroups: string[];
   levels: string[];
+  /** 소속 기준 라벨 (예: 당산클럽 소속) */
+  memberLabel?: string | null;
+  /** 팀당 최소 소속 인원. 0이면 제한 없음 */
+  minClubMembersPerTeam?: number;
 }
 
 function EventListField({
   eventTypes,
   ageGroups,
   levels,
+  memberLabel,
+  minClubMembersPerTeam = 0,
 }: EventListFieldProps) {
   const {
     control,
@@ -33,6 +39,31 @@ function EventListField({
 
   const players = watch('players') ?? [];
   const events = watch('events') ?? [];
+
+  const memberByKey = new Map(
+    players.map((player) => [player.key, player.isClubMember])
+  );
+  const clubLabel = memberLabel?.trim() || '클럽 소속';
+
+  /**
+   * 주최측에 본회 소속으로 등록하려면 팀에 소속 회원이 있어야 한다.
+   * 제출 후에야 알게 되면 늦으므로 배정하는 자리에서 바로 알린다.
+   */
+  const getShortfall = (playerKeys: string[]): number => {
+    if (minClubMembersPerTeam <= 0) return 0;
+    // 아직 고르지 않은 자리는 세지 않는다. 채우는 중에 경고가 뜨면 방해가 된다.
+    const chosen = playerKeys.filter(Boolean);
+    if (chosen.length === 0) return 0;
+    const memberCount = chosen.filter(
+      (key) => memberByKey.get(key) !== false
+    ).length;
+    const remaining = chosen.length - memberCount;
+    // 남은 빈 자리를 소속으로 채우면 조건을 만족할 수 있는지 본다.
+    const fillable = memberCount + (playerKeys.length - chosen.length);
+    return fillable >= minClubMembersPerTeam || remaining === 0
+      ? 0
+      : minClubMembersPerTeam - memberCount;
+  };
 
   const activeTypes = eventTypes.filter((eventType) => eventType.isActive);
   const typeById = new Map(activeTypes.map((type) => [type.id, type]));
@@ -149,6 +180,17 @@ function EventListField({
                   />
                 </FormField>
               ))}
+
+            {getShortfall(selected?.playerKeys ?? []) > 0 && (
+              <p
+                role="alert"
+                className="rounded-md bg-red-50 p-3 text-sm text-red-700"
+              >
+                이 종목은 {clubLabel} 회원이 최소 {minClubMembersPerTeam}명
+                필요합니다. 주최측에 본회 소속으로 등록하려면 팀에 소속 회원이
+                있어야 하므로, 외부 선수끼리는 신청할 수 없습니다.
+              </p>
+            )}
 
             {eventType && (
               <p className="text-right text-sm text-gray-600">

--- a/src/components/organisms/tournament/entry/PlayerListField.tsx
+++ b/src/components/organisms/tournament/entry/PlayerListField.tsx
@@ -23,9 +23,9 @@ import {
 
 interface PlayerListFieldProps {
   tshirtSizes: string[];
-  /** 회원 기준 라벨 (예: 영등포구 회원). 추가금 미사용 대회면 null */
+  /** 소속 기준 라벨 (예: 당산클럽 소속). 추가금 미사용 대회면 null */
   memberLabel: string | null;
-  /** 비회원 1인당 추가금. 0이면 회원 여부를 묻지 않는다 */
+  /** 외부 선수 1인당 추가금. 0이면 소속 여부를 묻지 않는다 */
   nonMemberSurcharge: number;
 }
 
@@ -220,7 +220,7 @@ function PlayerListField({
                 <input
                   type="checkbox"
                   className="mt-0.5 h-4 w-4"
-                  {...register(`players.${index}.isLocalMember`)}
+                  {...register(`players.${index}.isClubMember`)}
                 />
                 <span>
                   <span className="font-medium text-gray-800">

--- a/src/components/organisms/tournament/entry/PlayerListField.tsx
+++ b/src/components/organisms/tournament/entry/PlayerListField.tsx
@@ -215,24 +215,43 @@ function PlayerListField({
               )}
             </div>
 
-            {useSurcharge && (
-              <label className="flex items-start gap-2 rounded-md bg-gray-50 p-3 text-sm">
+            <div className="space-y-2 rounded-md bg-gray-50 p-3 text-sm">
+              {/* 클럽 소속은 금액과 무관하다. 임원이 명단을 파악하는 데 쓴다. */}
+              <label className="flex items-start gap-2">
                 <input
                   type="checkbox"
                   className="mt-0.5 h-4 w-4"
-                  {...register(`players.${index}.isLocalMember`)}
+                  {...register(`players.${index}.isClubMember`)}
                 />
                 <span>
                   <span className="font-medium text-gray-800">
-                    {memberLabel}
+                    우리 클럽 회원
                   </span>
                   <span className="ml-2 text-gray-500">
-                    해제하면 참가 종목마다 {nonMemberSurcharge.toLocaleString()}
-                    원이 추가됩니다.
+                    외부에서 함께 나가는 선수면 해제해주세요.
                   </span>
                 </span>
               </label>
-            )}
+
+              {useSurcharge && (
+                <label className="flex items-start gap-2">
+                  <input
+                    type="checkbox"
+                    className="mt-0.5 h-4 w-4"
+                    {...register(`players.${index}.isLocalMember`)}
+                  />
+                  <span>
+                    <span className="font-medium text-gray-800">
+                      {memberLabel}
+                    </span>
+                    <span className="ml-2 text-gray-500">
+                      해제하면 참가 종목마다{' '}
+                      {nonMemberSurcharge.toLocaleString()}원이 추가됩니다.
+                    </span>
+                  </span>
+                </label>
+              )}
+            </div>
           </div>
         );
       })}

--- a/src/components/organisms/tournament/entry/PlayerListField.tsx
+++ b/src/components/organisms/tournament/entry/PlayerListField.tsx
@@ -23,9 +23,17 @@ import {
 
 interface PlayerListFieldProps {
   tshirtSizes: string[];
+  /** 회원 기준 라벨 (예: 영등포구 회원). 추가금 미사용 대회면 null */
+  memberLabel: string | null;
+  /** 비회원 1인당 추가금. 0이면 회원 여부를 묻지 않는다 */
+  nonMemberSurcharge: number;
 }
 
-function PlayerListField({ tshirtSizes }: PlayerListFieldProps) {
+function PlayerListField({
+  tshirtSizes,
+  memberLabel,
+  nonMemberSurcharge,
+}: PlayerListFieldProps) {
   const {
     control,
     register,
@@ -40,6 +48,8 @@ function PlayerListField({ tshirtSizes }: PlayerListFieldProps) {
   const events = watch('events');
   const players = watch('players');
   const useTshirt = tshirtSizes.length > 0;
+  // 라벨이 있어야 무엇을 묻는지 알 수 있으므로 둘 다 있어야 노출한다
+  const useSurcharge = nonMemberSurcharge > 0 && !!memberLabel;
   const tshirtOptions = tshirtSizes.map((size) => ({
     value: size,
     label: size,
@@ -204,6 +214,25 @@ function PlayerListField({ tshirtSizes }: PlayerListFieldProps) {
                 </FormField>
               )}
             </div>
+
+            {useSurcharge && (
+              <label className="flex items-start gap-2 rounded-md bg-gray-50 p-3 text-sm">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4"
+                  {...register(`players.${index}.isLocalMember`)}
+                />
+                <span>
+                  <span className="font-medium text-gray-800">
+                    {memberLabel}
+                  </span>
+                  <span className="ml-2 text-gray-500">
+                    해제하면 참가 종목마다 {nonMemberSurcharge.toLocaleString()}
+                    원이 추가됩니다.
+                  </span>
+                </span>
+              </label>
+            )}
           </div>
         );
       })}

--- a/src/components/organisms/tournament/entry/PlayerListField.tsx
+++ b/src/components/organisms/tournament/entry/PlayerListField.tsx
@@ -215,43 +215,24 @@ function PlayerListField({
               )}
             </div>
 
-            <div className="space-y-2 rounded-md bg-gray-50 p-3 text-sm">
-              {/* 클럽 소속은 금액과 무관하다. 임원이 명단을 파악하는 데 쓴다. */}
-              <label className="flex items-start gap-2">
+            {useSurcharge && (
+              <label className="flex items-start gap-2 rounded-md bg-gray-50 p-3 text-sm">
                 <input
                   type="checkbox"
                   className="mt-0.5 h-4 w-4"
-                  {...register(`players.${index}.isClubMember`)}
+                  {...register(`players.${index}.isLocalMember`)}
                 />
                 <span>
                   <span className="font-medium text-gray-800">
-                    우리 클럽 회원
+                    {memberLabel}
                   </span>
                   <span className="ml-2 text-gray-500">
-                    외부에서 함께 나가는 선수면 해제해주세요.
+                    해제하면 참가 종목마다 {nonMemberSurcharge.toLocaleString()}
+                    원이 추가됩니다.
                   </span>
                 </span>
               </label>
-
-              {useSurcharge && (
-                <label className="flex items-start gap-2">
-                  <input
-                    type="checkbox"
-                    className="mt-0.5 h-4 w-4"
-                    {...register(`players.${index}.isLocalMember`)}
-                  />
-                  <span>
-                    <span className="font-medium text-gray-800">
-                      {memberLabel}
-                    </span>
-                    <span className="ml-2 text-gray-500">
-                      해제하면 참가 종목마다{' '}
-                      {nonMemberSurcharge.toLocaleString()}원이 추가됩니다.
-                    </span>
-                  </span>
-                </label>
-              )}
-            </div>
+            )}
           </div>
         );
       })}

--- a/src/components/organisms/tournament/entry/entryFormTypes.ts
+++ b/src/components/organisms/tournament/entry/entryFormTypes.ts
@@ -5,7 +5,7 @@ export interface PlayerFormValue {
   birthDate: string;
   phoneNumber: string;
   tshirtSize: string;
-  isLocalMember: boolean;
+  isClubMember: boolean;
 }
 
 export interface EventFormValue {
@@ -41,7 +41,7 @@ export function createEmptyPlayer(index: number): PlayerFormValue {
     birthDate: '',
     phoneNumber: '',
     tshirtSize: '',
-    // 기본은 회원. 비회원만 신청자가 체크를 해제한다.
-    isLocalMember: true,
+    // 기본은 소속. 외부 선수만 신청자가 체크를 해제한다.
+    isClubMember: true,
   };
 }

--- a/src/components/organisms/tournament/entry/entryFormTypes.ts
+++ b/src/components/organisms/tournament/entry/entryFormTypes.ts
@@ -6,6 +6,7 @@ export interface PlayerFormValue {
   phoneNumber: string;
   tshirtSize: string;
   isLocalMember: boolean;
+  isClubMember: boolean;
 }
 
 export interface EventFormValue {
@@ -43,5 +44,7 @@ export function createEmptyPlayer(index: number): PlayerFormValue {
     tshirtSize: '',
     // 기본은 회원. 비회원만 신청자가 체크를 해제한다.
     isLocalMember: true,
+    // 기본은 우리 클럽 사람. 외부 선수만 체크를 해제한다.
+    isClubMember: true,
   };
 }

--- a/src/components/organisms/tournament/entry/entryFormTypes.ts
+++ b/src/components/organisms/tournament/entry/entryFormTypes.ts
@@ -6,7 +6,6 @@ export interface PlayerFormValue {
   phoneNumber: string;
   tshirtSize: string;
   isLocalMember: boolean;
-  isClubMember: boolean;
 }
 
 export interface EventFormValue {
@@ -44,7 +43,5 @@ export function createEmptyPlayer(index: number): PlayerFormValue {
     tshirtSize: '',
     // 기본은 회원. 비회원만 신청자가 체크를 해제한다.
     isLocalMember: true,
-    // 기본은 우리 클럽 사람. 외부 선수만 체크를 해제한다.
-    isClubMember: true,
   };
 }

--- a/src/components/organisms/tournament/entry/entryFormTypes.ts
+++ b/src/components/organisms/tournament/entry/entryFormTypes.ts
@@ -5,6 +5,7 @@ export interface PlayerFormValue {
   birthDate: string;
   phoneNumber: string;
   tshirtSize: string;
+  isLocalMember: boolean;
 }
 
 export interface EventFormValue {
@@ -40,5 +41,7 @@ export function createEmptyPlayer(index: number): PlayerFormValue {
     birthDate: '',
     phoneNumber: '',
     tshirtSize: '',
+    // 기본은 회원. 비회원만 신청자가 체크를 해제한다.
+    isLocalMember: true,
   };
 }

--- a/src/hooks/useMyEntry.ts
+++ b/src/hooks/useMyEntry.ts
@@ -17,7 +17,7 @@ export type MyEntry = {
     birthDate: string;
     phoneNumber: string;
     tshirtSize: string | null;
-    isLocalMember: boolean;
+    isClubMember: boolean;
     order: number;
   }>;
   entryEvents: Array<{

--- a/src/hooks/useMyEntry.ts
+++ b/src/hooks/useMyEntry.ts
@@ -17,6 +17,7 @@ export type MyEntry = {
     birthDate: string;
     phoneNumber: string;
     tshirtSize: string | null;
+    isLocalMember: boolean;
     order: number;
   }>;
   entryEvents: Array<{

--- a/src/hooks/useMyEntry.ts
+++ b/src/hooks/useMyEntry.ts
@@ -18,6 +18,7 @@ export type MyEntry = {
     phoneNumber: string;
     tshirtSize: string | null;
     isLocalMember: boolean;
+    isClubMember: boolean;
     order: number;
   }>;
   entryEvents: Array<{

--- a/src/hooks/useMyEntry.ts
+++ b/src/hooks/useMyEntry.ts
@@ -18,7 +18,6 @@ export type MyEntry = {
     phoneNumber: string;
     tshirtSize: string | null;
     isLocalMember: boolean;
-    isClubMember: boolean;
     order: number;
   }>;
   entryEvents: Array<{

--- a/src/lib/tournament/csv.test.ts
+++ b/src/lib/tournament/csv.test.ts
@@ -21,7 +21,7 @@ const ENTRY = {
             birthDate: '1990-01-01',
             phoneNumber: '010-1111-2222',
             tshirtSize: 'L',
-            isLocalMember: true,
+            isClubMember: true,
           },
         },
         {
@@ -31,7 +31,7 @@ const ENTRY = {
             birthDate: '1988-05-05',
             phoneNumber: '010-3333-4444',
             tshirtSize: 'XL',
-            isLocalMember: false,
+            isClubMember: false,
           },
         },
       ],
@@ -56,7 +56,7 @@ describe('toCsvRows', () => {
       '1990-01-01',
       '010-1111-2222',
       'L',
-      '회원',
+      '소속',
       '번개클럽',
       '홍길동',
       '30000',
@@ -128,16 +128,16 @@ describe('toCsvString', () => {
   });
 });
 
-describe('toCsvRows - 회원 여부', () => {
-  it('회원 여부를 주최측이 읽을 수 있는 말로 적는다', () => {
-    const [member, nonMember] = toCsvRows([ENTRY]);
+describe('toCsvRows - 소속 여부', () => {
+  it('소속 여부를 주최측이 읽을 수 있는 말로 적는다', () => {
+    const [member, external] = toCsvRows([ENTRY]);
 
-    // 티셔츠(7) 다음 열이 회원 여부다.
-    expect(member[8]).toBe('회원');
-    expect(nonMember[8]).toBe('비회원');
+    // 티셔츠(7) 다음 열이 소속 여부다.
+    expect(member[8]).toBe('소속');
+    expect(external[8]).toBe('외부');
   });
 
-  it('헤더에 회원 여부 열이 있다', () => {
-    expect(CSV_HEADER[8]).toBe('회원여부');
+  it('헤더에 소속 여부 열이 있다', () => {
+    expect(CSV_HEADER[8]).toBe('소속여부');
   });
 });

--- a/src/lib/tournament/csv.test.ts
+++ b/src/lib/tournament/csv.test.ts
@@ -21,6 +21,7 @@ const ENTRY = {
             birthDate: '1990-01-01',
             phoneNumber: '010-1111-2222',
             tshirtSize: 'L',
+            isLocalMember: true,
           },
         },
         {
@@ -30,6 +31,7 @@ const ENTRY = {
             birthDate: '1988-05-05',
             phoneNumber: '010-3333-4444',
             tshirtSize: 'XL',
+            isLocalMember: false,
           },
         },
       ],
@@ -54,6 +56,7 @@ describe('toCsvRows', () => {
       '1990-01-01',
       '010-1111-2222',
       'L',
+      '회원',
       '번개클럽',
       '홍길동',
       '30000',
@@ -89,12 +92,12 @@ describe('toCsvRows', () => {
     };
     const [first] = toCsvRows([entry]);
     expect(first[7]).toBe('');
-    expect(first[8]).toBe('');
+    expect(first[9]).toBe('');
   });
 
   it('입금 상태를 한글로 변환한다', () => {
     const pending = toCsvRows([{ ...ENTRY, paymentStatus: 'PENDING' }]);
-    expect(pending[0][11]).toBe('입금대기');
+    expect(pending[0][12]).toBe('입금대기');
   });
 
   it('헤더 길이와 행 길이가 같다', () => {
@@ -122,5 +125,19 @@ describe('toCsvString', () => {
   it('행을 개행으로 잇는다', () => {
     const csv = toCsvString([['a'], ['b']]);
     expect(csv.replace('﻿', '')).toBe('a\r\nb');
+  });
+});
+
+describe('toCsvRows - 회원 여부', () => {
+  it('회원 여부를 주최측이 읽을 수 있는 말로 적는다', () => {
+    const [member, nonMember] = toCsvRows([ENTRY]);
+
+    // 티셔츠(7) 다음 열이 회원 여부다.
+    expect(member[8]).toBe('회원');
+    expect(nonMember[8]).toBe('비회원');
+  });
+
+  it('헤더에 회원 여부 열이 있다', () => {
+    expect(CSV_HEADER[8]).toBe('회원여부');
   });
 });

--- a/src/lib/tournament/csv.test.ts
+++ b/src/lib/tournament/csv.test.ts
@@ -22,7 +22,6 @@ const ENTRY = {
             phoneNumber: '010-1111-2222',
             tshirtSize: 'L',
             isLocalMember: true,
-            isClubMember: true,
           },
         },
         {
@@ -33,7 +32,6 @@ const ENTRY = {
             phoneNumber: '010-3333-4444',
             tshirtSize: 'XL',
             isLocalMember: false,
-            isClubMember: false,
           },
         },
       ],
@@ -58,7 +56,6 @@ describe('toCsvRows', () => {
       '1990-01-01',
       '010-1111-2222',
       'L',
-      '내부',
       '회원',
       '번개클럽',
       '홍길동',
@@ -95,12 +92,12 @@ describe('toCsvRows', () => {
     };
     const [first] = toCsvRows([entry]);
     expect(first[7]).toBe('');
-    expect(first[10]).toBe('');
+    expect(first[9]).toBe('');
   });
 
   it('입금 상태를 한글로 변환한다', () => {
     const pending = toCsvRows([{ ...ENTRY, paymentStatus: 'PENDING' }]);
-    expect(pending[0][13]).toBe('입금대기');
+    expect(pending[0][12]).toBe('입금대기');
   });
 
   it('헤더 길이와 행 길이가 같다', () => {
@@ -136,24 +133,11 @@ describe('toCsvRows - 회원 여부', () => {
     const [member, nonMember] = toCsvRows([ENTRY]);
 
     // 티셔츠(7) 다음 열이 회원 여부다.
-    expect(member[9]).toBe('회원');
-    expect(nonMember[9]).toBe('비회원');
+    expect(member[8]).toBe('회원');
+    expect(nonMember[8]).toBe('비회원');
   });
 
   it('헤더에 회원 여부 열이 있다', () => {
-    expect(CSV_HEADER[9]).toBe('회원여부');
-  });
-});
-
-describe('toCsvRows - 클럽 소속', () => {
-  it('내부·외부를 주최측이 읽을 수 있는 말로 적는다', () => {
-    const [internal, external] = toCsvRows([ENTRY]);
-
-    expect(internal[8]).toBe('내부');
-    expect(external[8]).toBe('외부');
-  });
-
-  it('헤더에 소속 열이 있다', () => {
-    expect(CSV_HEADER[8]).toBe('소속');
+    expect(CSV_HEADER[8]).toBe('회원여부');
   });
 });

--- a/src/lib/tournament/csv.test.ts
+++ b/src/lib/tournament/csv.test.ts
@@ -22,6 +22,7 @@ const ENTRY = {
             phoneNumber: '010-1111-2222',
             tshirtSize: 'L',
             isLocalMember: true,
+            isClubMember: true,
           },
         },
         {
@@ -32,6 +33,7 @@ const ENTRY = {
             phoneNumber: '010-3333-4444',
             tshirtSize: 'XL',
             isLocalMember: false,
+            isClubMember: false,
           },
         },
       ],
@@ -56,6 +58,7 @@ describe('toCsvRows', () => {
       '1990-01-01',
       '010-1111-2222',
       'L',
+      '내부',
       '회원',
       '번개클럽',
       '홍길동',
@@ -92,12 +95,12 @@ describe('toCsvRows', () => {
     };
     const [first] = toCsvRows([entry]);
     expect(first[7]).toBe('');
-    expect(first[9]).toBe('');
+    expect(first[10]).toBe('');
   });
 
   it('입금 상태를 한글로 변환한다', () => {
     const pending = toCsvRows([{ ...ENTRY, paymentStatus: 'PENDING' }]);
-    expect(pending[0][12]).toBe('입금대기');
+    expect(pending[0][13]).toBe('입금대기');
   });
 
   it('헤더 길이와 행 길이가 같다', () => {
@@ -133,11 +136,24 @@ describe('toCsvRows - 회원 여부', () => {
     const [member, nonMember] = toCsvRows([ENTRY]);
 
     // 티셔츠(7) 다음 열이 회원 여부다.
-    expect(member[8]).toBe('회원');
-    expect(nonMember[8]).toBe('비회원');
+    expect(member[9]).toBe('회원');
+    expect(nonMember[9]).toBe('비회원');
   });
 
   it('헤더에 회원 여부 열이 있다', () => {
-    expect(CSV_HEADER[8]).toBe('회원여부');
+    expect(CSV_HEADER[9]).toBe('회원여부');
+  });
+});
+
+describe('toCsvRows - 클럽 소속', () => {
+  it('내부·외부를 주최측이 읽을 수 있는 말로 적는다', () => {
+    const [internal, external] = toCsvRows([ENTRY]);
+
+    expect(internal[8]).toBe('내부');
+    expect(external[8]).toBe('외부');
+  });
+
+  it('헤더에 소속 열이 있다', () => {
+    expect(CSV_HEADER[8]).toBe('소속');
   });
 });

--- a/src/lib/tournament/csv.ts
+++ b/src/lib/tournament/csv.ts
@@ -20,7 +20,7 @@ export type CsvEntry = {
         birthDate: string;
         phoneNumber: string;
         tshirtSize: string | null;
-        isLocalMember: boolean;
+        isClubMember: boolean;
       };
     }>;
   }>;
@@ -35,7 +35,7 @@ export const CSV_HEADER = [
   '생년월일',
   '전화번호',
   '티셔츠',
-  '회원여부',
+  '소속여부',
   '팀명',
   '입금자명',
   '참가비',
@@ -66,7 +66,7 @@ export function toCsvRows(entries: CsvEntry[]): string[][] {
           entryPlayer.birthDate,
           entryPlayer.phoneNumber,
           entryPlayer.tshirtSize ?? '',
-          entryPlayer.isLocalMember ? '회원' : '비회원',
+          entryPlayer.isClubMember ? '소속' : '외부',
           entry.teamName ?? '',
           entry.depositorName,
           String(event.fee),

--- a/src/lib/tournament/csv.ts
+++ b/src/lib/tournament/csv.ts
@@ -20,6 +20,7 @@ export type CsvEntry = {
         birthDate: string;
         phoneNumber: string;
         tshirtSize: string | null;
+        isLocalMember: boolean;
       };
     }>;
   }>;
@@ -34,6 +35,7 @@ export const CSV_HEADER = [
   '생년월일',
   '전화번호',
   '티셔츠',
+  '회원여부',
   '팀명',
   '입금자명',
   '참가비',
@@ -64,6 +66,7 @@ export function toCsvRows(entries: CsvEntry[]): string[][] {
           entryPlayer.birthDate,
           entryPlayer.phoneNumber,
           entryPlayer.tshirtSize ?? '',
+          entryPlayer.isLocalMember ? '회원' : '비회원',
           entry.teamName ?? '',
           entry.depositorName,
           String(event.fee),

--- a/src/lib/tournament/csv.ts
+++ b/src/lib/tournament/csv.ts
@@ -21,6 +21,7 @@ export type CsvEntry = {
         phoneNumber: string;
         tshirtSize: string | null;
         isLocalMember: boolean;
+        isClubMember: boolean;
       };
     }>;
   }>;
@@ -35,6 +36,7 @@ export const CSV_HEADER = [
   '생년월일',
   '전화번호',
   '티셔츠',
+  '소속',
   '회원여부',
   '팀명',
   '입금자명',
@@ -66,6 +68,7 @@ export function toCsvRows(entries: CsvEntry[]): string[][] {
           entryPlayer.birthDate,
           entryPlayer.phoneNumber,
           entryPlayer.tshirtSize ?? '',
+          entryPlayer.isClubMember ? '내부' : '외부',
           entryPlayer.isLocalMember ? '회원' : '비회원',
           entry.teamName ?? '',
           entry.depositorName,

--- a/src/lib/tournament/csv.ts
+++ b/src/lib/tournament/csv.ts
@@ -21,7 +21,6 @@ export type CsvEntry = {
         phoneNumber: string;
         tshirtSize: string | null;
         isLocalMember: boolean;
-        isClubMember: boolean;
       };
     }>;
   }>;
@@ -36,7 +35,6 @@ export const CSV_HEADER = [
   '생년월일',
   '전화번호',
   '티셔츠',
-  '소속',
   '회원여부',
   '팀명',
   '입금자명',
@@ -68,7 +66,6 @@ export function toCsvRows(entries: CsvEntry[]): string[][] {
           entryPlayer.birthDate,
           entryPlayer.phoneNumber,
           entryPlayer.tshirtSize ?? '',
-          entryPlayer.isClubMember ? '내부' : '외부',
           entryPlayer.isLocalMember ? '회원' : '비회원',
           entry.teamName ?? '',
           entry.depositorName,

--- a/src/lib/tournament/fee.test.ts
+++ b/src/lib/tournament/fee.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { calculateTotalFee } from './fee';
+import { calculateEventFee, calculateTotalFee } from './fee';
 
 describe('calculateTotalFee', () => {
   it('ACTIVE 종목의 참가비만 합산한다', () => {
@@ -33,5 +33,82 @@ describe('calculateTotalFee', () => {
 
   it('참가비가 0원인 무료 대회도 처리한다', () => {
     expect(calculateTotalFee([{ fee: 0, status: 'ACTIVE' }])).toBe(0);
+  });
+});
+
+describe('calculateEventFee', () => {
+  const player = (key: string, isLocalMember: boolean) => ({
+    key,
+    isLocalMember,
+  });
+
+  it('추가금이 0원이면 종목 참가비를 그대로 반환한다', () => {
+    const result = calculateEventFee({
+      baseFee: 60000,
+      surcharge: 0,
+      playerKeys: ['a', 'b'],
+      players: [player('a', true), player('b', false)],
+    });
+    expect(result).toBe(60000);
+  });
+
+  it('비회원 선수 1명이면 추가금을 1회 더한다', () => {
+    const result = calculateEventFee({
+      baseFee: 60000,
+      surcharge: 10000,
+      playerKeys: ['a', 'b'],
+      players: [player('a', true), player('b', false)],
+    });
+    expect(result).toBe(70000);
+  });
+
+  it('비회원 선수 2명이면 추가금을 2회 더한다', () => {
+    const result = calculateEventFee({
+      baseFee: 60000,
+      surcharge: 10000,
+      playerKeys: ['a', 'b'],
+      players: [player('a', false), player('b', false)],
+    });
+    expect(result).toBe(80000);
+  });
+
+  it('모두 회원이면 추가금이 붙지 않는다', () => {
+    const result = calculateEventFee({
+      baseFee: 60000,
+      surcharge: 10000,
+      playerKeys: ['a', 'b'],
+      players: [player('a', true), player('b', true)],
+    });
+    expect(result).toBe(60000);
+  });
+
+  it('단식 종목에서 비회원이면 추가금을 1회만 더한다', () => {
+    const result = calculateEventFee({
+      baseFee: 30000,
+      surcharge: 10000,
+      playerKeys: ['a'],
+      players: [player('a', false), player('b', false)],
+    });
+    expect(result).toBe(40000);
+  });
+
+  it('해당 종목에 배정되지 않은 비회원은 계산에서 제외한다', () => {
+    const result = calculateEventFee({
+      baseFee: 60000,
+      surcharge: 10000,
+      playerKeys: ['a', 'b'],
+      players: [player('a', true), player('b', true), player('c', false)],
+    });
+    expect(result).toBe(60000);
+  });
+
+  it('존재하지 않는 선수 key는 무시한다', () => {
+    const result = calculateEventFee({
+      baseFee: 60000,
+      surcharge: 10000,
+      playerKeys: ['a', 'missing'],
+      players: [player('a', false)],
+    });
+    expect(result).toBe(70000);
   });
 });

--- a/src/lib/tournament/fee.test.ts
+++ b/src/lib/tournament/fee.test.ts
@@ -37,9 +37,9 @@ describe('calculateTotalFee', () => {
 });
 
 describe('calculateEventFee', () => {
-  const player = (key: string, isLocalMember: boolean) => ({
+  const player = (key: string, isClubMember: boolean) => ({
     key,
-    isLocalMember,
+    isClubMember,
   });
 
   it('추가금이 0원이면 종목 참가비를 그대로 반환한다', () => {
@@ -52,7 +52,7 @@ describe('calculateEventFee', () => {
     expect(result).toBe(60000);
   });
 
-  it('비회원 선수 1명이면 추가금을 1회 더한다', () => {
+  it('외부 선수 1명이면 추가금을 1회 더한다', () => {
     const result = calculateEventFee({
       baseFee: 60000,
       surcharge: 10000,
@@ -62,7 +62,7 @@ describe('calculateEventFee', () => {
     expect(result).toBe(70000);
   });
 
-  it('비회원 선수 2명이면 추가금을 2회 더한다', () => {
+  it('외부 선수 2명이면 추가금을 2회 더한다', () => {
     const result = calculateEventFee({
       baseFee: 60000,
       surcharge: 10000,
@@ -72,7 +72,7 @@ describe('calculateEventFee', () => {
     expect(result).toBe(80000);
   });
 
-  it('모두 회원이면 추가금이 붙지 않는다', () => {
+  it('모두 소속이면 추가금이 붙지 않는다', () => {
     const result = calculateEventFee({
       baseFee: 60000,
       surcharge: 10000,
@@ -82,7 +82,7 @@ describe('calculateEventFee', () => {
     expect(result).toBe(60000);
   });
 
-  it('단식 종목에서 비회원이면 추가금을 1회만 더한다', () => {
+  it('단식 종목에서 외부 선수면 추가금을 1회만 더한다', () => {
     const result = calculateEventFee({
       baseFee: 30000,
       surcharge: 10000,
@@ -92,7 +92,7 @@ describe('calculateEventFee', () => {
     expect(result).toBe(40000);
   });
 
-  it('해당 종목에 배정되지 않은 비회원은 계산에서 제외한다', () => {
+  it('해당 종목에 배정되지 않은 외부 선수는 계산에서 제외한다', () => {
     const result = calculateEventFee({
       baseFee: 60000,
       surcharge: 10000,

--- a/src/lib/tournament/fee.ts
+++ b/src/lib/tournament/fee.ts
@@ -17,13 +17,13 @@ export function calculateTotalFee(events: FeeCalculable[]): number {
 
 export type SurchargeablePlayer = {
   key: string;
-  isLocalMember: boolean;
+  isClubMember: boolean;
 };
 
 export type EventFeeInput = {
   /** 종목에 정의된 기본 참가비 */
   baseFee: number;
-  /** 비회원 1인당 추가금. 0이면 추가금 미사용 */
+  /** 외부 선수 1인당 추가금. 0이면 추가금 미사용 */
   surcharge: number;
   /** 이 종목에 배정된 선수 key 목록 */
   playerKeys: string[];
@@ -34,8 +34,8 @@ export type EventFeeInput = {
 /**
  * 종목 1줄의 참가비를 계산한다.
  *
- * 규칙이 "팀당 60,000원, 회원이 아닌 경우 1인당 1만원 추가"이므로
- * 추가금은 그 종목에 배정된 비회원 수만큼 붙는다.
+ * 규칙이 "팀당 60,000원, 소속이 아닌 경우 1인당 1만원 추가"이므로
+ * 추가금은 그 종목에 배정된 외부 선수 수만큼 붙는다.
  * 한 선수가 여러 종목에 나가면 종목마다 각각 부과된다.
  */
 export function calculateEventFee({
@@ -47,12 +47,12 @@ export function calculateEventFee({
   if (surcharge <= 0) return baseFee;
 
   const memberByKey = new Map(
-    players.map((player) => [player.key, player.isLocalMember])
+    players.map((player) => [player.key, player.isClubMember])
   );
-  // 명단에 없는 key는 검증 단계에서 걸러지므로 여기서는 회원으로 본다
-  const nonMemberCount = playerKeys.filter(
+  // 명단에 없는 key는 검증 단계에서 걸러지므로 여기서는 소속으로 본다
+  const externalCount = playerKeys.filter(
     (key) => memberByKey.get(key) === false
   ).length;
 
-  return baseFee + nonMemberCount * surcharge;
+  return baseFee + externalCount * surcharge;
 }

--- a/src/lib/tournament/fee.ts
+++ b/src/lib/tournament/fee.ts
@@ -14,3 +14,45 @@ export function calculateTotalFee(events: FeeCalculable[]): number {
     .filter((event) => event.status === 'ACTIVE')
     .reduce((sum, event) => sum + event.fee, 0);
 }
+
+export type SurchargeablePlayer = {
+  key: string;
+  isLocalMember: boolean;
+};
+
+export type EventFeeInput = {
+  /** 종목에 정의된 기본 참가비 */
+  baseFee: number;
+  /** 비회원 1인당 추가금. 0이면 추가금 미사용 */
+  surcharge: number;
+  /** 이 종목에 배정된 선수 key 목록 */
+  playerKeys: string[];
+  /** 신청서 전체 선수 명단 */
+  players: SurchargeablePlayer[];
+};
+
+/**
+ * 종목 1줄의 참가비를 계산한다.
+ *
+ * 규칙이 "팀당 60,000원, 회원이 아닌 경우 1인당 1만원 추가"이므로
+ * 추가금은 그 종목에 배정된 비회원 수만큼 붙는다.
+ * 한 선수가 여러 종목에 나가면 종목마다 각각 부과된다.
+ */
+export function calculateEventFee({
+  baseFee,
+  surcharge,
+  playerKeys,
+  players,
+}: EventFeeInput): number {
+  if (surcharge <= 0) return baseFee;
+
+  const memberByKey = new Map(
+    players.map((player) => [player.key, player.isLocalMember])
+  );
+  // 명단에 없는 key는 검증 단계에서 걸러지므로 여기서는 회원으로 본다
+  const nonMemberCount = playerKeys.filter(
+    (key) => memberByKey.get(key) === false
+  ).length;
+
+  return baseFee + nonMemberCount * surcharge;
+}

--- a/src/lib/tournament/groupEntriesByEvent.test.ts
+++ b/src/lib/tournament/groupEntriesByEvent.test.ts
@@ -35,6 +35,7 @@ function createEntry(options: {
           phoneNumber: `010-0000-000${name.length}`,
           tshirtSize: null,
           isLocalMember: true,
+          isClubMember: true,
         },
       })),
     })),

--- a/src/lib/tournament/groupEntriesByEvent.test.ts
+++ b/src/lib/tournament/groupEntriesByEvent.test.ts
@@ -34,7 +34,7 @@ function createEntry(options: {
           birthDate: '1990-03-15',
           phoneNumber: `010-0000-000${name.length}`,
           tshirtSize: null,
-          isLocalMember: true,
+          isClubMember: true,
         },
       })),
     })),

--- a/src/lib/tournament/groupEntriesByEvent.test.ts
+++ b/src/lib/tournament/groupEntriesByEvent.test.ts
@@ -35,7 +35,6 @@ function createEntry(options: {
           phoneNumber: `010-0000-000${name.length}`,
           tshirtSize: null,
           isLocalMember: true,
-          isClubMember: true,
         },
       })),
     })),

--- a/src/lib/tournament/groupEntriesByEvent.test.ts
+++ b/src/lib/tournament/groupEntriesByEvent.test.ts
@@ -34,6 +34,7 @@ function createEntry(options: {
           birthDate: '1990-03-15',
           phoneNumber: `010-0000-000${name.length}`,
           tshirtSize: null,
+          isLocalMember: true,
         },
       })),
     })),

--- a/src/lib/tournament/groupEntriesByEvent.ts
+++ b/src/lib/tournament/groupEntriesByEvent.ts
@@ -9,7 +9,6 @@ export interface GroupedPlayer {
   phoneNumber: string;
   tshirtSize: string | null;
   isLocalMember: boolean;
-  isClubMember: boolean;
 }
 
 /**
@@ -49,7 +48,6 @@ interface GroupableEntry {
         phoneNumber: string;
         tshirtSize: string | null;
         isLocalMember: boolean;
-        isClubMember: boolean;
       };
     }>;
   }>;
@@ -93,7 +91,6 @@ export function groupEntriesByEvent(entries: GroupableEntry[]): EventGroup[] {
           phoneNumber: eventPlayer.entryPlayer.phoneNumber,
           tshirtSize: eventPlayer.entryPlayer.tshirtSize,
           isLocalMember: eventPlayer.entryPlayer.isLocalMember,
-          isClubMember: eventPlayer.entryPlayer.isClubMember,
         })),
       });
       groups.set(label, teams);

--- a/src/lib/tournament/groupEntriesByEvent.ts
+++ b/src/lib/tournament/groupEntriesByEvent.ts
@@ -8,6 +8,7 @@ export interface GroupedPlayer {
   birthDate: string;
   phoneNumber: string;
   tshirtSize: string | null;
+  isLocalMember: boolean;
 }
 
 /**
@@ -46,6 +47,7 @@ interface GroupableEntry {
         birthDate: string;
         phoneNumber: string;
         tshirtSize: string | null;
+        isLocalMember: boolean;
       };
     }>;
   }>;
@@ -88,6 +90,7 @@ export function groupEntriesByEvent(entries: GroupableEntry[]): EventGroup[] {
           birthDate: eventPlayer.entryPlayer.birthDate,
           phoneNumber: eventPlayer.entryPlayer.phoneNumber,
           tshirtSize: eventPlayer.entryPlayer.tshirtSize,
+          isLocalMember: eventPlayer.entryPlayer.isLocalMember,
         })),
       });
       groups.set(label, teams);

--- a/src/lib/tournament/groupEntriesByEvent.ts
+++ b/src/lib/tournament/groupEntriesByEvent.ts
@@ -8,7 +8,7 @@ export interface GroupedPlayer {
   birthDate: string;
   phoneNumber: string;
   tshirtSize: string | null;
-  isLocalMember: boolean;
+  isClubMember: boolean;
 }
 
 /**
@@ -47,7 +47,7 @@ interface GroupableEntry {
         birthDate: string;
         phoneNumber: string;
         tshirtSize: string | null;
-        isLocalMember: boolean;
+        isClubMember: boolean;
       };
     }>;
   }>;
@@ -90,7 +90,7 @@ export function groupEntriesByEvent(entries: GroupableEntry[]): EventGroup[] {
           birthDate: eventPlayer.entryPlayer.birthDate,
           phoneNumber: eventPlayer.entryPlayer.phoneNumber,
           tshirtSize: eventPlayer.entryPlayer.tshirtSize,
-          isLocalMember: eventPlayer.entryPlayer.isLocalMember,
+          isClubMember: eventPlayer.entryPlayer.isClubMember,
         })),
       });
       groups.set(label, teams);

--- a/src/lib/tournament/groupEntriesByEvent.ts
+++ b/src/lib/tournament/groupEntriesByEvent.ts
@@ -9,6 +9,7 @@ export interface GroupedPlayer {
   phoneNumber: string;
   tshirtSize: string | null;
   isLocalMember: boolean;
+  isClubMember: boolean;
 }
 
 /**
@@ -48,6 +49,7 @@ interface GroupableEntry {
         phoneNumber: string;
         tshirtSize: string | null;
         isLocalMember: boolean;
+        isClubMember: boolean;
       };
     }>;
   }>;
@@ -91,6 +93,7 @@ export function groupEntriesByEvent(entries: GroupableEntry[]): EventGroup[] {
           phoneNumber: eventPlayer.entryPlayer.phoneNumber,
           tshirtSize: eventPlayer.entryPlayer.tshirtSize,
           isLocalMember: eventPlayer.entryPlayer.isLocalMember,
+          isClubMember: eventPlayer.entryPlayer.isClubMember,
         })),
       });
       groups.set(label, teams);

--- a/src/lib/tournament/validation.test.ts
+++ b/src/lib/tournament/validation.test.ts
@@ -30,7 +30,6 @@ function makeInput(
         phoneNumber: '010-1111-2222',
         tshirtSize: 'L',
         isLocalMember: true,
-        isClubMember: true,
         order: 0,
       },
       {
@@ -41,7 +40,6 @@ function makeInput(
         phoneNumber: '010-3333-4444',
         tshirtSize: 'XL',
         isLocalMember: true,
-        isClubMember: true,
         order: 1,
       },
     ],

--- a/src/lib/tournament/validation.test.ts
+++ b/src/lib/tournament/validation.test.ts
@@ -6,9 +6,9 @@ import { validateEntrySubmission } from './validation';
 
 const TOURNAMENT = {
   eventTypes: [
-    { id: 'et-double', playerCount: 2, isActive: true },
-    { id: 'et-single', playerCount: 1, isActive: true },
-    { id: 'et-inactive', playerCount: 2, isActive: false },
+    { id: 'et-double', name: '남자복식', playerCount: 2, isActive: true },
+    { id: 'et-single', name: '남자단식', playerCount: 1, isActive: true },
+    { id: 'et-inactive', name: '혼합복식', playerCount: 2, isActive: false },
   ],
   ageGroups: ['30대', '40대'],
   levels: ['A조', 'B조'],
@@ -365,5 +365,94 @@ describe('validateEntrySubmission', () => {
       TOURNAMENT
     );
     expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('validateEntrySubmission - 팀당 최소 소속 인원', () => {
+  /** 최소 소속 인원 규칙을 쓰는 대회 */
+  const RULED = {
+    ...TOURNAMENT,
+    memberLabel: '당산클럽 소속',
+    minClubMembersPerTeam: 1,
+  };
+
+  /** p1/p2의 소속 여부를 지정한 신청서를 만든다. */
+  function makeInputWithMembers(p1: boolean, p2: boolean) {
+    const input = makeInput();
+    return {
+      ...input,
+      players: [
+        { ...input.players[0], isClubMember: p1 },
+        { ...input.players[1], isClubMember: p2 },
+      ],
+    };
+  }
+
+  it('소속 회원이 1명 이상이면 통과한다', () => {
+    const result = validateEntrySubmission(
+      makeInputWithMembers(true, false),
+      RULED
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('전원 소속이면 통과한다', () => {
+    const result = validateEntrySubmission(
+      makeInputWithMembers(true, true),
+      RULED
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('전원 외부면 거부하고 이유를 알려준다', () => {
+    const result = validateEntrySubmission(
+      makeInputWithMembers(false, false),
+      RULED
+    );
+    expect(result).toEqual({
+      ok: false,
+      error:
+        '한 종목에 당산클럽 소속이 최소 1명 있어야 신청할 수 있습니다. (남자복식 30대 A조)',
+    });
+  });
+
+  it('제한이 0이면 전원 외부여도 통과한다', () => {
+    const result = validateEntrySubmission(makeInputWithMembers(false, false), {
+      ...RULED,
+      minClubMembersPerTeam: 0,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('최소 2명을 요구하면 1명만 소속인 팀을 거부한다', () => {
+    const result = validateEntrySubmission(makeInputWithMembers(true, false), {
+      ...RULED,
+      minClubMembersPerTeam: 2,
+    });
+    expect(result).toEqual({
+      ok: false,
+      error:
+        '한 종목에 당산클럽 소속이 최소 2명 있어야 신청할 수 있습니다. (남자복식 30대 A조)',
+    });
+  });
+
+  it('단식은 필요 인원이 1명이므로 소속 1명을 요구한다', () => {
+    const input = makeInput();
+    const result = validateEntrySubmission(
+      {
+        ...input,
+        players: [{ ...input.players[0], isClubMember: false }],
+        events: [
+          {
+            eventTypeId: 'et-single',
+            ageGroup: '30대',
+            level: 'A조',
+            playerKeys: ['p1'],
+          },
+        ],
+      },
+      RULED
+    );
+    expect(result.ok).toBe(false);
   });
 });

--- a/src/lib/tournament/validation.test.ts
+++ b/src/lib/tournament/validation.test.ts
@@ -29,7 +29,7 @@ function makeInput(
         birthDate: '1990-01-01',
         phoneNumber: '010-1111-2222',
         tshirtSize: 'L',
-        isLocalMember: true,
+        isClubMember: true,
         order: 0,
       },
       {
@@ -39,7 +39,7 @@ function makeInput(
         birthDate: '1988-05-05',
         phoneNumber: '010-3333-4444',
         tshirtSize: 'XL',
-        isLocalMember: true,
+        isClubMember: true,
         order: 1,
       },
     ],

--- a/src/lib/tournament/validation.test.ts
+++ b/src/lib/tournament/validation.test.ts
@@ -30,6 +30,7 @@ function makeInput(
         phoneNumber: '010-1111-2222',
         tshirtSize: 'L',
         isLocalMember: true,
+        isClubMember: true,
         order: 0,
       },
       {
@@ -40,6 +41,7 @@ function makeInput(
         phoneNumber: '010-3333-4444',
         tshirtSize: 'XL',
         isLocalMember: true,
+        isClubMember: true,
         order: 1,
       },
     ],

--- a/src/lib/tournament/validation.test.ts
+++ b/src/lib/tournament/validation.test.ts
@@ -29,6 +29,7 @@ function makeInput(
         birthDate: '1990-01-01',
         phoneNumber: '010-1111-2222',
         tshirtSize: 'L',
+        isLocalMember: true,
         order: 0,
       },
       {
@@ -38,6 +39,7 @@ function makeInput(
         birthDate: '1988-05-05',
         phoneNumber: '010-3333-4444',
         tshirtSize: 'XL',
+        isLocalMember: true,
         order: 1,
       },
     ],

--- a/src/lib/tournament/validation.ts
+++ b/src/lib/tournament/validation.ts
@@ -1,7 +1,10 @@
 import type { EntrySubmissionInput } from '@/types/tournament.types';
 
+import { formatEventLabel } from './display';
+
 export type ValidatableEventType = {
   id: string;
+  name: string;
   playerCount: number;
   isActive: boolean;
 };
@@ -10,6 +13,10 @@ export type ValidatableTournament = {
   eventTypes: ValidatableEventType[];
   ageGroups: string[];
   levels: string[];
+  /** 소속 기준 라벨 (예: 당산클럽 소속). 오류 메시지에 쓴다 */
+  memberLabel?: string | null;
+  /** 팀당 최소 소속 인원. 0이면 제한 없음 */
+  minClubMembersPerTeam?: number;
 };
 
 export type ValidationResult = { ok: true } | { ok: false; error: string };
@@ -56,6 +63,11 @@ export function validateEntrySubmission(
   // 대회가 급수를 쓰지 않으면 빈 문자열만 허용한다
   const usesLevel = tournament.levels.length > 0;
 
+  const minClubMembers = tournament.minClubMembersPerTeam ?? 0;
+  const memberByKey = new Map(
+    input.players.map((player) => [player.key, player.isClubMember])
+  );
+
   const seenCombinations = new Set<string>();
 
   for (const event of input.events) {
@@ -81,6 +93,25 @@ export function validateEntrySubmission(
       return fail(
         `종목별 선수 인원이 맞지 않습니다. (필요: ${eventType.playerCount}명)`
       );
+    }
+
+    // 주최측에 본회 소속으로 등록하려면 팀에 소속 회원이 있어야 한다.
+    // 외부 선수만으로 이루어진 팀은 등록 자체가 불가능하므로 여기서 막는다.
+    if (minClubMembers > 0) {
+      const clubMemberCount = event.playerKeys.filter(
+        (key) => memberByKey.get(key) !== false
+      ).length;
+      if (clubMemberCount < minClubMembers) {
+        const label = tournament.memberLabel?.trim() || '클럽 소속';
+        const eventLabel = formatEventLabel({
+          eventType: eventType.name,
+          ageGroup: event.ageGroup,
+          level: event.level,
+        });
+        return fail(
+          `한 종목에 ${label}이 최소 ${minClubMembers}명 있어야 신청할 수 있습니다. (${eventLabel})`
+        );
+      }
     }
     if (new Set(event.playerKeys).size !== event.playerKeys.length) {
       return fail('한 종목에 같은 선수를 중복 배정할 수 없습니다.');

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/[entryId]/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/[entryId]/index.ts
@@ -117,6 +117,7 @@ export default withAuth(async function handler(
                 ? (player.tshirtSize ?? null)
                 : null,
             isLocalMember: useSurcharge ? player.isLocalMember : true,
+            isClubMember: player.isClubMember,
             order: player.order,
           },
         });

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/[entryId]/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/[entryId]/index.ts
@@ -117,7 +117,6 @@ export default withAuth(async function handler(
                 ? (player.tshirtSize ?? null)
                 : null,
             isLocalMember: useSurcharge ? player.isLocalMember : true,
-            isClubMember: player.isClubMember,
             order: player.order,
           },
         });

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/[entryId]/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/[entryId]/index.ts
@@ -76,7 +76,7 @@ export default withAuth(async function handler(
     const useSurcharge = entry.tournament.nonMemberSurcharge > 0;
     const surchargePlayers = input.players.map((player) => ({
       key: player.key,
-      isLocalMember: useSurcharge ? player.isLocalMember : true,
+      isClubMember: useSurcharge ? player.isClubMember : true,
     }));
 
     // 수정된 선수 구성으로 종목별 금액을 다시 계산한다.
@@ -116,7 +116,7 @@ export default withAuth(async function handler(
               entry.tournament.tshirtSizes.length > 0
                 ? (player.tshirtSize ?? null)
                 : null,
-            isLocalMember: useSurcharge ? player.isLocalMember : true,
+            isClubMember: useSurcharge ? player.isClubMember : true,
             order: player.order,
           },
         });

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/[entryId]/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/[entryId]/index.ts
@@ -6,7 +6,7 @@ import {
   handleApiError,
   parseClubId,
 } from '@/lib/tournament/apiHelpers';
-import { calculateTotalFee } from '@/lib/tournament/fee';
+import { calculateEventFee, calculateTotalFee } from '@/lib/tournament/fee';
 import { isAcceptingEntries } from '@/lib/tournament/status';
 import { validateEntrySubmission } from '@/lib/tournament/validation';
 import { entrySubmissionSchema } from '@/schemas/tournament.schema';
@@ -72,14 +72,28 @@ export default withAuth(async function handler(
     const feeById = new Map(
       entry.tournament.eventTypes.map((e) => [e.id, e.fee])
     );
+    // 추가금을 쓰지 않는 대회면 모든 선수를 회원으로 취급해 추가금을 0으로 만든다
+    const useSurcharge = entry.tournament.nonMemberSurcharge > 0;
+    const surchargePlayers = input.players.map((player) => ({
+      key: player.key,
+      isLocalMember: useSurcharge ? player.isLocalMember : true,
+    }));
+
+    // 수정된 선수 구성으로 종목별 금액을 다시 계산한다.
+    // 회원 여부를 바꾸면 금액도 함께 갱신되어야 한다.
+    const feeByEventIndex = input.events.map((event) =>
+      calculateEventFee({
+        baseFee: feeById.get(event.eventTypeId) ?? 0,
+        surcharge: entry.tournament.nonMemberSurcharge,
+        playerKeys: event.playerKeys,
+        players: surchargePlayers,
+      })
+    );
     const canceledEvents = entry.entryEvents.filter(
       (event) => event.status === 'CANCELED'
     );
     const totalFee = calculateTotalFee([
-      ...input.events.map((event) => ({
-        fee: feeById.get(event.eventTypeId) ?? 0,
-        status: 'ACTIVE' as const,
-      })),
+      ...feeByEventIndex.map((fee) => ({ fee, status: 'ACTIVE' as const })),
       ...canceledEvents,
     ]);
 
@@ -102,20 +116,22 @@ export default withAuth(async function handler(
               entry.tournament.tshirtSizes.length > 0
                 ? (player.tshirtSize ?? null)
                 : null,
+            isLocalMember: useSurcharge ? player.isLocalMember : true,
             order: player.order,
           },
         });
         keyToPlayerId.set(player.key, createdPlayer.id);
       }
 
-      for (const event of input.events) {
+      for (const [index, event] of input.events.entries()) {
         const entryEvent = await tx.entryEvent.create({
           data: {
             entryId,
             eventTypeId: event.eventTypeId,
             ageGroup: event.ageGroup,
             level: event.level,
-            fee: feeById.get(event.eventTypeId) ?? 0,
+            // 추가금이 반영된 최종 금액을 스냅샷으로 남긴다
+            fee: feeByEventIndex[index],
           },
         });
         await tx.entryEventPlayer.createMany({

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/export.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/export.ts
@@ -63,7 +63,6 @@ export default withAuth(async function handler(
                     phoneNumber: true,
                     tshirtSize: true,
                     isLocalMember: true,
-                    isClubMember: true,
                   },
                 },
               },

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/export.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/export.ts
@@ -62,7 +62,7 @@ export default withAuth(async function handler(
                     birthDate: true,
                     phoneNumber: true,
                     tshirtSize: true,
-                    isLocalMember: true,
+                    isClubMember: true,
                   },
                 },
               },

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/export.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/export.ts
@@ -63,6 +63,7 @@ export default withAuth(async function handler(
                     phoneNumber: true,
                     tshirtSize: true,
                     isLocalMember: true,
+                    isClubMember: true,
                   },
                 },
               },

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/export.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/export.ts
@@ -62,6 +62,7 @@ export default withAuth(async function handler(
                     birthDate: true,
                     phoneNumber: true,
                     tshirtSize: true,
+                    isLocalMember: true,
                   },
                 },
               },

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/index.ts
@@ -144,6 +144,7 @@ export default withAuth(async function handler(
                   ? (player.tshirtSize ?? null)
                   : null,
               isLocalMember: useSurcharge ? player.isLocalMember : true,
+              isClubMember: player.isClubMember,
               order: player.order,
             },
           });

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/index.ts
@@ -144,7 +144,6 @@ export default withAuth(async function handler(
                   ? (player.tshirtSize ?? null)
                   : null,
               isLocalMember: useSurcharge ? player.isLocalMember : true,
-              isClubMember: player.isClubMember,
               order: player.order,
             },
           });

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/index.ts
@@ -89,7 +89,7 @@ export default withAuth(async function handler(
       const useSurcharge = tournament.nonMemberSurcharge > 0;
       const surchargePlayers = input.players.map((player) => ({
         key: player.key,
-        isLocalMember: useSurcharge ? player.isLocalMember : true,
+        isClubMember: useSurcharge ? player.isClubMember : true,
       }));
 
       // 클라이언트가 보낸 금액은 무시하고 DB 값으로 종목별 금액을 계산한다.
@@ -143,7 +143,7 @@ export default withAuth(async function handler(
                 tournament.tshirtSizes.length > 0
                   ? (player.tshirtSize ?? null)
                   : null,
-              isLocalMember: useSurcharge ? player.isLocalMember : true,
+              isClubMember: useSurcharge ? player.isClubMember : true,
               order: player.order,
             },
           });

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/entries/index.ts
@@ -6,7 +6,7 @@ import {
   handleApiError,
   parseClubId,
 } from '@/lib/tournament/apiHelpers';
-import { calculateTotalFee } from '@/lib/tournament/fee';
+import { calculateEventFee, calculateTotalFee } from '@/lib/tournament/fee';
 import { isAcceptingEntries } from '@/lib/tournament/status';
 import { validateEntrySubmission } from '@/lib/tournament/validation';
 import { entrySubmissionSchema } from '@/schemas/tournament.schema';
@@ -85,12 +85,25 @@ export default withAuth(async function handler(
       const feeById = new Map(
         tournament.eventTypes.map((eventType) => [eventType.id, eventType.fee])
       );
-      // 클라이언트가 보낸 금액은 무시하고 DB 값으로 총액을 계산한다
+      // 추가금을 쓰지 않는 대회면 모든 선수를 회원으로 취급해 추가금을 0으로 만든다
+      const useSurcharge = tournament.nonMemberSurcharge > 0;
+      const surchargePlayers = input.players.map((player) => ({
+        key: player.key,
+        isLocalMember: useSurcharge ? player.isLocalMember : true,
+      }));
+
+      // 클라이언트가 보낸 금액은 무시하고 DB 값으로 종목별 금액을 계산한다.
+      // 이 값이 EntryEvent.fee 스냅샷이자 totalFee의 재료가 된다.
+      const feeByEventIndex = input.events.map((event) =>
+        calculateEventFee({
+          baseFee: feeById.get(event.eventTypeId) ?? 0,
+          surcharge: tournament.nonMemberSurcharge,
+          playerKeys: event.playerKeys,
+          players: surchargePlayers,
+        })
+      );
       const totalFee = calculateTotalFee(
-        input.events.map((event) => ({
-          fee: feeById.get(event.eventTypeId) ?? 0,
-          status: 'ACTIVE' as const,
-        }))
+        feeByEventIndex.map((fee) => ({ fee, status: 'ACTIVE' as const }))
       );
 
       const created = await prisma.$transaction(async (tx) => {
@@ -130,20 +143,23 @@ export default withAuth(async function handler(
                 tournament.tshirtSizes.length > 0
                   ? (player.tshirtSize ?? null)
                   : null,
+              isLocalMember: useSurcharge ? player.isLocalMember : true,
               order: player.order,
             },
           });
           keyToPlayerId.set(player.key, createdPlayer.id);
         }
 
-        for (const event of input.events) {
+        for (const [index, event] of input.events.entries()) {
           const entryEvent = await tx.entryEvent.create({
             data: {
               entryId: entry.id,
               eventTypeId: event.eventTypeId,
               ageGroup: event.ageGroup,
               level: event.level,
-              fee: feeById.get(event.eventTypeId) ?? 0,
+              // 추가금이 반영된 최종 금액을 스냅샷으로 남긴다.
+              // 종목 취소 시 이 금액이 통째로 빠진다.
+              fee: feeByEventIndex[index],
             },
           });
           await tx.entryEventPlayer.createMany({

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/index.ts
@@ -144,6 +144,8 @@ export default withAuth(async function handler(
             useTeamName: input.useTeamName,
             tshirtSizes: input.tshirtSizes,
             bankAccount: input.bankAccount ?? null,
+            memberLabel: input.memberLabel?.trim() || null,
+            nonMemberSurcharge: input.nonMemberSurcharge,
             ageGroups: input.ageGroups,
             levels: input.levels,
           },

--- a/src/pages/api/clubs/[id]/tournaments/[tournamentId]/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/[tournamentId]/index.ts
@@ -146,6 +146,7 @@ export default withAuth(async function handler(
             bankAccount: input.bankAccount ?? null,
             memberLabel: input.memberLabel?.trim() || null,
             nonMemberSurcharge: input.nonMemberSurcharge,
+            minClubMembersPerTeam: input.minClubMembersPerTeam,
             ageGroups: input.ageGroups,
             levels: input.levels,
           },

--- a/src/pages/api/clubs/[id]/tournaments/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/index.ts
@@ -81,6 +81,7 @@ export default withAuth(async function handler(
           bankAccount: input.bankAccount ?? null,
           memberLabel: input.memberLabel?.trim() || null,
           nonMemberSurcharge: input.nonMemberSurcharge,
+          minClubMembersPerTeam: input.minClubMembersPerTeam,
           ageGroups: input.ageGroups,
           levels: input.levels,
           createdBy: member.id,

--- a/src/pages/api/clubs/[id]/tournaments/index.ts
+++ b/src/pages/api/clubs/[id]/tournaments/index.ts
@@ -79,6 +79,8 @@ export default withAuth(async function handler(
           useTeamName: input.useTeamName,
           tshirtSizes: input.tshirtSizes,
           bankAccount: input.bankAccount ?? null,
+          memberLabel: input.memberLabel?.trim() || null,
+          nonMemberSurcharge: input.nonMemberSurcharge,
           ageGroups: input.ageGroups,
           levels: input.levels,
           createdBy: member.id,

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/admin.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/admin.tsx
@@ -196,6 +196,11 @@ function TournamentAdminPage() {
         <EventGroupList
           groups={eventGroups}
           useTeamName={detail?.tournament.useTeamName ?? false}
+          memberLabel={
+            (detail?.tournament.nonMemberSurcharge ?? 0) > 0
+              ? detail?.tournament.memberLabel
+              : null
+          }
         />
       )}
     </div>

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
@@ -65,6 +65,7 @@ function TournamentApplyPage() {
         birthDate: player.birthDate,
         phoneNumber: player.phoneNumber,
         tshirtSize: player.tshirtSize ?? '',
+        isLocalMember: player.isLocalMember,
       })),
       events: myEntry.entryEvents
         .filter((event) => event.status === 'ACTIVE')
@@ -105,6 +106,7 @@ function TournamentApplyPage() {
             birthDate: player.birthDate,
             phoneNumber: player.phoneNumber,
             tshirtSize: player.tshirtSize || null,
+            isLocalMember: player.isLocalMember,
             order: index,
           })),
           events: values.events.map((event) => ({
@@ -162,7 +164,11 @@ function TournamentApplyPage() {
 
       <FormProvider {...methods}>
         <form onSubmit={onSubmitForm} className="space-y-8">
-          <PlayerListField tshirtSizes={detail.tournament.tshirtSizes} />
+          <PlayerListField
+            tshirtSizes={detail.tournament.tshirtSizes}
+            memberLabel={detail.tournament.memberLabel}
+            nonMemberSurcharge={detail.tournament.nonMemberSurcharge}
+          />
           <EventListField
             eventTypes={detail.tournament.eventTypes}
             ageGroups={detail.tournament.ageGroups}
@@ -172,6 +178,7 @@ function TournamentApplyPage() {
             eventTypes={detail.tournament.eventTypes}
             useTeamName={detail.tournament.useTeamName}
             bankAccount={detail.tournament.bankAccount}
+            nonMemberSurcharge={detail.tournament.nonMemberSurcharge}
           />
 
           {/* 개별 필드 메시지가 화면 밖에 있으면 버튼이 먹통처럼 보인다.

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
@@ -65,7 +65,7 @@ function TournamentApplyPage() {
         birthDate: player.birthDate,
         phoneNumber: player.phoneNumber,
         tshirtSize: player.tshirtSize ?? '',
-        isLocalMember: player.isLocalMember,
+        isClubMember: player.isClubMember,
       })),
       events: myEntry.entryEvents
         .filter((event) => event.status === 'ACTIVE')
@@ -106,7 +106,7 @@ function TournamentApplyPage() {
             birthDate: player.birthDate,
             phoneNumber: player.phoneNumber,
             tshirtSize: player.tshirtSize || null,
-            isLocalMember: player.isLocalMember,
+            isClubMember: player.isClubMember,
             order: index,
           })),
           events: values.events.map((event) => ({

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
@@ -19,6 +19,7 @@ import TournamentFileList from '@/components/organisms/tournament/TournamentFile
 import { useMyEntry, useSubmitEntry } from '@/hooks/useMyEntry';
 import { useTournamentDetail } from '@/hooks/useTournamentDetail';
 
+import { validateEntrySubmission } from '@/lib/tournament/validation';
 import { RootState } from '@/store';
 
 function TournamentApplyPage() {
@@ -92,6 +93,31 @@ function TournamentApplyPage() {
   }, [myEntry, clubMember, methods]);
 
   const onSubmitForm = methods.handleSubmit(async (values) => {
+    if (!detail) return;
+
+    // 서버와 같은 규칙으로 미리 걸러 낸다. 규칙은 validation.ts 한 곳에만 둔다.
+    const precheck = validateEntrySubmission(
+      {
+        depositorName: values.depositorName,
+        teamName: values.teamName || null,
+        privacyAgreed: true,
+        players: values.players.map((player, index) => ({
+          ...player,
+          tshirtSize: player.tshirtSize || null,
+          order: index,
+        })),
+        events: values.events.map((event) => ({
+          ...event,
+          playerKeys: event.playerKeys.filter(Boolean),
+        })),
+      },
+      detail.tournament
+    );
+    if (!precheck.ok) {
+      toast.error(precheck.error);
+      return;
+    }
+
     try {
       await submitEntry.mutateAsync({
         entryId: myEntry?.id ?? null,
@@ -173,6 +199,8 @@ function TournamentApplyPage() {
             eventTypes={detail.tournament.eventTypes}
             ageGroups={detail.tournament.ageGroups}
             levels={detail.tournament.levels}
+            memberLabel={detail.tournament.memberLabel}
+            minClubMembersPerTeam={detail.tournament.minClubMembersPerTeam}
           />
           <EntrySummary
             eventTypes={detail.tournament.eventTypes}

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
@@ -66,6 +66,7 @@ function TournamentApplyPage() {
         phoneNumber: player.phoneNumber,
         tshirtSize: player.tshirtSize ?? '',
         isLocalMember: player.isLocalMember,
+        isClubMember: player.isClubMember,
       })),
       events: myEntry.entryEvents
         .filter((event) => event.status === 'ACTIVE')
@@ -107,6 +108,7 @@ function TournamentApplyPage() {
             phoneNumber: player.phoneNumber,
             tshirtSize: player.tshirtSize || null,
             isLocalMember: player.isLocalMember,
+            isClubMember: player.isClubMember,
             order: index,
           })),
           events: values.events.map((event) => ({

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/apply.tsx
@@ -66,7 +66,6 @@ function TournamentApplyPage() {
         phoneNumber: player.phoneNumber,
         tshirtSize: player.tshirtSize ?? '',
         isLocalMember: player.isLocalMember,
-        isClubMember: player.isClubMember,
       })),
       events: myEntry.entryEvents
         .filter((event) => event.status === 'ACTIVE')
@@ -108,7 +107,6 @@ function TournamentApplyPage() {
             phoneNumber: player.phoneNumber,
             tshirtSize: player.tshirtSize || null,
             isLocalMember: player.isLocalMember,
-            isClubMember: player.isClubMember,
             order: index,
           })),
           events: values.events.map((event) => ({

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/edit.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/edit.tsx
@@ -66,6 +66,7 @@ function EditTournamentPage() {
     bankAccount: tournament.bankAccount ?? '',
     memberLabel: tournament.memberLabel ?? '',
     nonMemberSurcharge: tournament.nonMemberSurcharge,
+    minClubMembersPerTeam: tournament.minClubMembersPerTeam,
     ageGroups: tournament.ageGroups,
     levels: tournament.levels,
     // 비활성 종목은 편집 목록에서 제외한다.

--- a/src/pages/clubs/[id]/tournaments/[tournamentId]/edit.tsx
+++ b/src/pages/clubs/[id]/tournaments/[tournamentId]/edit.tsx
@@ -64,6 +64,8 @@ function EditTournamentPage() {
     useTeamName: tournament.useTeamName,
     tshirtSizes: tournament.tshirtSizes,
     bankAccount: tournament.bankAccount ?? '',
+    memberLabel: tournament.memberLabel ?? '',
+    nonMemberSurcharge: tournament.nonMemberSurcharge,
     ageGroups: tournament.ageGroups,
     levels: tournament.levels,
     // 비활성 종목은 편집 목록에서 제외한다.

--- a/src/pages/clubs/[id]/tournaments/new.tsx
+++ b/src/pages/clubs/[id]/tournaments/new.tsx
@@ -24,6 +24,7 @@ const EMPTY_TOURNAMENT: TournamentInput = {
   bankAccount: '',
   memberLabel: '',
   nonMemberSurcharge: 0,
+  minClubMembersPerTeam: 0,
   ageGroups: [],
   levels: [],
   eventTypes: [{ name: '', playerCount: 2, fee: 0, order: 0 }],

--- a/src/pages/clubs/[id]/tournaments/new.tsx
+++ b/src/pages/clubs/[id]/tournaments/new.tsx
@@ -22,6 +22,8 @@ const EMPTY_TOURNAMENT: TournamentInput = {
   useTeamName: false,
   tshirtSizes: [],
   bankAccount: '',
+  memberLabel: '',
+  nonMemberSurcharge: 0,
   ageGroups: [],
   levels: [],
   eventTypes: [{ name: '', playerCount: 2, fee: 0, order: 0 }],

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -70,7 +70,7 @@ export const tournamentInputSchema = z
   .refine(
     (input) => input.nonMemberSurcharge === 0 || !!input.memberLabel?.trim(),
     {
-      message: '추가금을 사용하려면 회원 기준 라벨을 입력해주세요.',
+      message: '추가금을 사용하려면 소속 기준 라벨을 입력해주세요.',
       path: ['memberLabel'],
     }
   );
@@ -97,7 +97,7 @@ const playerSchema = z.object({
     .transform(formatPhoneNumber),
   tshirtSize: z.string().trim().nullable().optional(),
   // 추가금 미사용 대회에서는 서버가 항상 true로 덮으므로 기본값을 둔다
-  isLocalMember: z.boolean().default(true),
+  isClubMember: z.boolean().default(true),
   order: z.number().int().min(0).default(0),
 });
 

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -98,6 +98,8 @@ const playerSchema = z.object({
   tshirtSize: z.string().trim().nullable().optional(),
   // 추가금 미사용 대회에서는 서버가 항상 true로 덮으므로 기본값을 둔다
   isLocalMember: z.boolean().default(true),
+  // 우리 클럽 소속 여부. 금액과 무관해 항상 그대로 저장한다.
+  isClubMember: z.boolean().default(true),
   order: z.number().int().min(0).default(0),
 });
 

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -36,6 +36,13 @@ export const tournamentInputSchema = z
       .int()
       .min(0, '추가금은 0원 이상이어야 합니다.')
       .default(0),
+    // 복식이 최대 2명이므로 그 이상은 어떤 종목도 통과할 수 없다
+    minClubMembersPerTeam: z
+      .number()
+      .int()
+      .min(0, '최소 인원은 0명 이상이어야 합니다.')
+      .max(2, '최소 인원은 2명을 넘을 수 없습니다.')
+      .default(0),
     ageGroups: z
       .array(z.string().trim().min(1))
       .min(1, '연령을 1개 이상 등록해주세요.'),

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -30,6 +30,12 @@ export const tournamentInputSchema = z
     useTeamName: z.boolean(),
     tshirtSizes: z.array(z.string().trim().min(1)),
     bankAccount: z.string().trim().nullable().optional(),
+    memberLabel: z.string().trim().nullable().optional(),
+    nonMemberSurcharge: z
+      .number()
+      .int()
+      .min(0, '추가금은 0원 이상이어야 합니다.')
+      .default(0),
     ageGroups: z
       .array(z.string().trim().min(1))
       .min(1, '연령을 1개 이상 등록해주세요.'),
@@ -59,7 +65,15 @@ export const tournamentInputSchema = z
   .refine((input) => new Set(input.levels).size === input.levels.length, {
     message: '중복된 급수가 있습니다.',
     path: ['levels'],
-  });
+  })
+  // 추가금을 쓰면 신청 화면 체크박스에 표시할 기준 라벨이 반드시 필요하다
+  .refine(
+    (input) => input.nonMemberSurcharge === 0 || !!input.memberLabel?.trim(),
+    {
+      message: '추가금을 사용하려면 회원 기준 라벨을 입력해주세요.',
+      path: ['memberLabel'],
+    }
+  );
 
 const playerSchema = z.object({
   key: z.string().min(1),
@@ -82,6 +96,8 @@ const playerSchema = z.object({
     .refine(isValidPhoneNumber, '올바른 전화번호가 아닙니다.')
     .transform(formatPhoneNumber),
   tshirtSize: z.string().trim().nullable().optional(),
+  // 추가금 미사용 대회에서는 서버가 항상 true로 덮으므로 기본값을 둔다
+  isLocalMember: z.boolean().default(true),
   order: z.number().int().min(0).default(0),
 });
 

--- a/src/schemas/tournament.schema.ts
+++ b/src/schemas/tournament.schema.ts
@@ -98,8 +98,6 @@ const playerSchema = z.object({
   tshirtSize: z.string().trim().nullable().optional(),
   // 추가금 미사용 대회에서는 서버가 항상 true로 덮으므로 기본값을 둔다
   isLocalMember: z.boolean().default(true),
-  // 우리 클럽 소속 여부. 금액과 무관해 항상 그대로 저장한다.
-  isClubMember: z.boolean().default(true),
   order: z.number().int().min(0).default(0),
 });
 

--- a/src/types/tournament.types.ts
+++ b/src/types/tournament.types.ts
@@ -77,6 +77,7 @@ export interface PlayerInput {
   phoneNumber: string;
   tshirtSize?: string | null;
   isLocalMember: boolean;
+  isClubMember: boolean;
   order: number;
 }
 

--- a/src/types/tournament.types.ts
+++ b/src/types/tournament.types.ts
@@ -63,6 +63,7 @@ export interface TournamentInput {
   bankAccount?: string | null;
   memberLabel?: string | null;
   nonMemberSurcharge: number;
+  minClubMembersPerTeam: number;
   ageGroups: string[];
   levels: string[];
   eventTypes: EventTypeInput[];

--- a/src/types/tournament.types.ts
+++ b/src/types/tournament.types.ts
@@ -76,7 +76,7 @@ export interface PlayerInput {
   birthDate: string;
   phoneNumber: string;
   tshirtSize?: string | null;
-  isLocalMember: boolean;
+  isClubMember: boolean;
   order: number;
 }
 

--- a/src/types/tournament.types.ts
+++ b/src/types/tournament.types.ts
@@ -61,6 +61,8 @@ export interface TournamentInput {
   useTeamName: boolean;
   tshirtSizes: string[];
   bankAccount?: string | null;
+  memberLabel?: string | null;
+  nonMemberSurcharge: number;
   ageGroups: string[];
   levels: string[];
   eventTypes: EventTypeInput[];
@@ -74,6 +76,7 @@ export interface PlayerInput {
   birthDate: string;
   phoneNumber: string;
   tshirtSize?: string | null;
+  isLocalMember: boolean;
   order: number;
 }
 

--- a/src/types/tournament.types.ts
+++ b/src/types/tournament.types.ts
@@ -77,7 +77,6 @@ export interface PlayerInput {
   phoneNumber: string;
   tshirtSize?: string | null;
   isLocalMember: boolean;
-  isClubMember: boolean;
   order: number;
 }
 


### PR DESCRIPTION
## 배경

주최측 규칙에 따라 대회 참가비가 팀 구성원에 따라 달라진다.

> 본회 소속 클럽으로 출전 시 팀당 60,000원이며, 영등포구 회원이 아닌 경우
> 1인당 1만원 추가되어 팀당 70,000원을 납부하여야 한다.

기존 참가비는 **종목당 정액**이라 선수 개인의 소속 여부를 금액에 반영할 수 없었다.
또 클럽 사람이 외부 선수와 함께 나가는 경우를 임원이 구분할 방법이 없었다.

## 요구사항

논의를 거쳐 확정한 요구사항이다. 구현 내용은 아래 "무엇을 했나"에 대응한다.

### R1. 외부 선수 참가비 추가금

| 항목 | 결정 |
| --- | --- |
| 계산식 | `기본 참가비 + (종목에 배정된 외부 인원 × 추가금)` |
| 부과 단위 | **종목마다** — 한 선수가 2종목 나가면 각각 부과 |
| 판단 기준 | 신청자가 선수별로 직접 체크 (클럽 회원 여부로 자동 판단하지 않음) |
| 금액 설정 | **대회마다** 관리자가 입력 (코드 고정 아님) |
| 미사용 시 | 추가금 0이면 체크박스를 노출하지 않음 → 기존 대회 영향 없음 |

### R2. 비회원(외부 선수) 등록 방법

**회원이 대신 신청(대리 신청)** 으로 결정. 공개 신청 링크는 범위에서 제외했다.

기존 `EntryPlayer`가 이미 자유 입력 구조라 선수 명단에 외부인을 추가하는 것으로 해결된다.
로그인·인증·권한 변경이 없어 작업 범위가 가장 작다.

### R3. 관리자 화면에서 내부/외부 구분

임원이 통장 대조와 주최측 제출 명단을 만들 때 필요하다.

| 화면 | 표시 |
| --- | --- |
| 신청서 단위 | 신청자 아래 `외부 N명` + 해당 선수 이름 |
| 종목 단위 | 선수 줄에 `{라벨} 아님` 태그 |
| CSV | `소속여부` 열 (소속/외부) |

**모바일·PC 양쪽 반영이 요구사항이었다.** `EntryTable`은 카드와 표를 별도 마크업으로
그리므로 둘 다 넣었고, 좁은 화면에서 배지가 찌그러지지 않도록 `flex-wrap` 처리했다.

### R4. 팀 구성 제한 — 외부 선수끼리 신청 금지

> 외부인 두 명이 대회에 참가하려면 한 명이 당산클럽 소속으로 서울시에 등록해야 한다.
> 두 명 다 다른 클럽 소속이면 참여가 어렵다.

**신청을 받아도 실제 대회 등록이 불가능한 조합**이므로 신청 단계에서 막는다.
세부 조건: 선수를 채우는 도중에는 경고하지 않는다. 남은 빈 자리를 소속 회원으로
채울 수 있으면 참았다가, 조합이 확정적으로 불가능해질 때만 알린다.

### R5. 대회별 설정

주최측 규칙이 대회마다 다르므로 코드에 고정하지 않는다.
기본값이 모두 0/빈값이라 **기존 대회는 동작이 바뀌지 않는다.**
(새 대회도 기본은 꺼져 있어 관리자가 명시적으로 켜야 한다.)

### 범위에서 뺀 것

| 항목 | 이유 |
| --- | --- |
| 비회원 직접 신청(공개 링크) | 대리 신청으로 충분. 필요해지면 `TournamentEntry.userId` nullable 작업 |
| 전화번호로 클럽 회원 자동 대조 | 등록률 88%라 클럽 회원 10명 중 1명이 외부로 오판됨 |
| 종목별 추가금 차등 | 현재 규칙에 과잉 |

## 무엇을 했나

### 1. 참가비 계산 (`calculateEventFee`)

```
종목 1줄의 fee = 기본 참가비 + (그 종목 배정 선수 중 외부 인원수 × 추가금)
```

| 종목 | 배정 선수 | 계산 | 결과 |
| --- | --- | --- | --- |
| 남자복식 | 홍길동(소속), 김철수(외부) | 60,000 + 1×10,000 | 70,000 |
| 남자복식 | 소속 2명 | 60,000 | 60,000 |
| 남자복식 | 외부 2명 | — | **신청 불가** (아래 참고) |

추가금이 반영된 **최종 금액을 `EntryEvent.fee` 스냅샷에 저장**하므로,
기존 총액 합산·부분 취소·CSV 로직은 수정 없이 그대로 동작한다.
종목을 취소하면 추가금 포함 금액이 통째로 빠져 규칙과 일치한다.

### 2. 팀당 최소 소속 인원 제한

주최측에 본회 소속으로 등록하려면 팀에 소속 회원이 있어야 한다.
**외부 선수끼리 팀을 짜면 실제 대회 등록이 불가능**하므로 신청 단계에서 막는다.

규칙은 `validateEntrySubmission` 한 곳에 두고, 서버와 클라이언트가 같은 함수를 호출한다.

| 지점 | 동작 |
| --- | --- |
| 신청 화면 | 선수를 배정하는 자리에서 즉시 경고 |
| 제출 버튼 | 토스트로 거부, 제출되지 않음 |
| 서버 API | 클라이언트를 우회해도 400 |

> 이 종목은 **당산클럽 소속** 회원이 최소 1명 필요합니다. 주최측에 본회 소속으로
> 등록하려면 팀에 소속 회원이 있어야 하므로, 외부 선수끼리는 신청할 수 없습니다.

선수를 채우는 도중에는 경고하지 않는다. 아직 고르지 않은 자리를 소속 회원으로
채울 수 있으면 참았다가, 조합이 확정적으로 불가능해질 때만 알린다.

### 3. 대회별 설정

관리자가 대회마다 입력한다. 주최측 규칙이 대회마다 다르므로 코드에 고정하지 않았다.

```
외부 선수 1인당 추가금
  소속 기준: [당산클럽 소속]     ← memberLabel
  추가금:   [10,000] 원          ← nonMemberSurcharge
팀당 최소 소속 인원: [1]          ← minClubMembersPerTeam
```

**추가금 0 / 최소 인원 0이면 기존 대회와 동일하게 동작한다.**

### 4. 화면

| 화면 | 변경 |
| --- | --- |
| 대회 생성·수정 | 외부 선수 추가금 설정 (라벨 + 금액) |
| 신청 | 선수별 소속 체크박스, 합계에 `기본 + 추가금` 내역 표시 |
| 관리자 — 신청서 단위 | 신청자 아래 `외부 N명` + 해당 선수 이름 (모바일·PC 양쪽) |
| 관리자 — 종목 단위 | 선수 줄에 `{라벨} 아님` 태그 |
| CSV | `소속여부` 열 추가 |

### 5. 서버 검증

클라이언트가 보낸 금액은 무시하고 **서버가 DB 값으로 재계산**하는 기존 원칙을 유지했다.
신청·수정 API 양쪽에 적용.

## DB 마이그레이션 (중요)

**이 브랜치의 마이그레이션 3건은 이미 프로덕션에 적용되어 있습니다.**
`_prisma_migrations` 이력도 기록 완료했고, `migrate status`는 `Database schema is up to date!`를 반환합니다.

| 마이그레이션 | 내용 |
| --- | --- |
| `20260822000000` | `Tournament.memberLabel`, `nonMemberSurcharge` 추가 |
| `20260823010000` | `EntryPlayer.isLocalMember` → `isClubMember` 일원화 |
| `20260823020000` | `Tournament.minClubMembersPerTeam` 추가 |

`20260823010000`은 `UPDATE`로 값을 옮긴 뒤 옛 컬럼을 지운다.
`migrate diff`는 `DROP`만 출력하므로 그대로 썼다면 데이터가 사라졌을 것이라 `UPDATE`를 직접 앞에 넣었다.
적용 결과 외부 선수 7건이 그대로 보존된 것을 확인했다 (선수 총 32건, 손실 없음).

### 커밋 이력에 대해

규칙 문구("영등포구 회원")와 운영 실제("당산클럽 소속")가 달랐던 탓에 설계가 한 번 뒤집혔다.

| 순서 | 내용 |
| --- | --- |
| `edaa35e` | 두 기준이 별개 축이라 보고 `isClubMember`를 **별도 필드로 추가** |
| `6b1fec2` | 실제로는 `memberLabel`에 `'당산클럽 소속'`을 쓰고 있어 신청 화면에 같은 뜻 체크박스가 2개 → **revert** |
| `3719514` | `isLocalMember` → `isClubMember` **하나로 일원화** |

설계 단계에서 운영 중인 실제 입력값을 먼저 확인했다면 앞의 두 커밋을 건너뛸 수 있었다.

## 테스트

- **337개 통과** (이번 브랜치에서 32개 추가)
- `calculateEventFee` 단위 테스트 7개 — 추가금 0원, 외부 1명/2명, 단식, 미배정 선수 제외 등
- `validateEntrySubmission` 최소 소속 인원 테스트 6개 — 소속 1명/전원 소속/전원 외부/제한 0/최소 2명/단식
- `PlayerListField` / `EventGroupList` / `EntryTable` / `EventListField` DOM 테스트
- 각 테스트가 구현 없이 실패하는 것을 확인한 뒤 구현 (TDD)

> 기존 실패 16건(`sms-notification`, `GuestPageStrategy`)은 이 브랜치 이전부터 실패하던 것으로 본 변경과 무관합니다.

## 함께 포함된 별건 수정

`26b4db2` — 개인정보 동의 문구에 `'당산배드민턴클럽'`이 하드코딩되어 있어 제거했다.
다른 클럽 사용자에게 잘못된 고지가 나가던 문제로, 이번 기능과는 무관한 기존 버그다.

이번 작업 중 하드코딩을 점검하다 발견했다. 아래 2건은 **아직 남아 있다.**

| 위치 | 내용 |
| --- | --- |
| `_app.tsx:80` | SEO 키워드에 `'당산클럽, 당산 클럽, …'` |
| `SideMenu.tsx:103,110` | `href="/clubs/1/members"` — 클럽 ID 1 고정. 다른 클럽에서 엉뚱한 페이지로 이동 |

## 리뷰 포인트

- `src/lib/tournament/fee.ts` — 계산 로직. 종목마다 부과되는 게 규칙과 맞는지
- `entries/index.ts`, `entries/[entryId]/index.ts` — 신청·수정 양쪽에서 동일하게 재계산하는지
- `20260823010000` 마이그레이션 — `UPDATE` → `DROP` 순서
- `EventListField`의 `getShortfall` — 입력 도중 경고를 참는 조건이 적절한지


