### PR TITLE
fix(privacy): 개인정보 동의 문구에서 특정 클럽명 제거

### DIFF
--- a/src/components/organisms/modal/PrivacyModal.tsx
+++ b/src/components/organisms/modal/PrivacyModal.tsx
@@ -13,9 +13,7 @@ function PrivacyModal({ isOpen, onClose }: PrivacyModalProps) {
       <div className="bg-white rounded-lg p-6 w-full max-w-md">
         <h3 className="text-lg font-bold mb-4">개인정보 수집 및 이용에 동의</h3>
         <div className="mb-4 text-sm">
-          <p className="mb-2">
-            1. 수집/이용 목적 : 당산배드민턴클럽 가입 및 문의
-          </p>
+          <p className="mb-2">1. 수집/이용 목적 : 배드민턴클럽 가입 및 문의</p>
           <p className="mb-2">
             2. 수집하는 항목 : 이름, 연락처, 생년월일, 성별
           </p>


### PR DESCRIPTION
## 배경

개인정보 수집·이용 동의 문구에 특정 클럽명이 하드코딩되어 있었다.

```
1. 수집/이용 목적 : 당산배드민턴클럽 가입 및 문의
```

이 서비스는 여러 클럽을 담을 수 있는 구조인데, 어느 클럽 사용자가 가입하든
`당산배드민턴클럽` 이름으로 동의를 받게 된다. **법적 고지 문구라 잘못된 주체가
표시되면 동의 자체의 유효성이 문제가 될 수 있다.**

## 변경

```diff
- 1. 수집/이용 목적 : 당산배드민턴클럽 가입 및 문의
+ 1. 수집/이용 목적 : 배드민턴클럽 가입 및 문의
```

클럽명을 빼고 일반 문구로 바꿨다. 나머지 항목(수집 항목·보유 기간 등)은 그대로다.

## 남아 있는 하드코딩

대회 참가비 작업(#67) 중 하드코딩을 점검하다 발견한 건이다. 같은 성격으로 **2건이 더 남아 있다.**

| 위치 | 내용 | 영향 |
| --- | --- | --- |
| `src/components/organisms/navigation/mainNavigation/SideMenu.tsx:103,110` | `href="/clubs/1/members"` — 클럽 ID 고정 | **다른 클럽 사용자가 메뉴를 누르면 클럽 1번 페이지로 이동** |
| `src/pages/_app.tsx:80` | SEO 키워드 `'당산클럽, 당산 클럽, …'` | 검색 노출이 특정 클럽에 치우침 |

`SideMenu` 건이 기능적으로 더 위험하지만, 현재 운영 중인 클럽이 하나뿐이라면
당장 드러나지 않는다. 이번 PR 범위에서는 제외했다.

## 확인

- `tsc --noEmit` 통과
- 테스트 337개 통과 (기존 실패 16건은 `sms-notification`·`GuestPageStrategy`로 본 변경과 무관)
- 문구 한 줄 변경이라 로직 영향 없음
